### PR TITLE
Add musl target for Alpine support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,5 @@ test:
 build: clean
 	$(DC) run -e GOARCH=386   dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-i386
 	$(DC) run -e GOARCH=amd64 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-amd64
+	# musl target does not support sqlite
+	$(DC) run -e GOARCH=amd64 -e CGO_ENABLED=0 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-musl-amd64

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ Creating: myapp_test
 Applying: 20151127184807_create_users_table.sql
 ```
 
+## FAQ
+
+**How do I use dbmate under Alpine linux?**
+
+Alpine linux uses [musl libc](https://www.musl-libc.org/), which is incompatible with how we build SQLite support (using [cgo](https://golang.org/cmd/cgo/)). If you want Alpine linux support, and don't mind sacrificing SQLite support, please use the `dbmate-linux-musl-amd64` build found on the [releases page](https://github.com/amacneil/dbmate/releases).
+
 ## Contributing
 
 Dbmate is written in Go, pull requests are welcome.


### PR DESCRIPTION
Building with `CGO_ENABLED=0` results in a binary which can run on Alpine linux (with musl libc), but it also disables SQLite support.

Adding an additional target allows people to decide this tradeoff for themselves.