### PR TITLE
Add darwin build target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.8
 
-# required to force cgo (for sqlite driver) with cross compile
-ENV CGO_ENABLED 1
-
 # i386 cross compilation
 RUN dpkg --add-architecture i386 && \
 	apt-get update && \
@@ -11,6 +8,7 @@ RUN dpkg --add-architecture i386 && \
 
 # development dependencies
 RUN go get \
+	github.com/mitchellh/gox \
 	github.com/golang/lint/golint \
 	github.com/kisielk/errcheck
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN go get \
 	github.com/kisielk/errcheck
 
 # copy source files
-COPY . $GOPATH/src/github.com/amacneil/dbmate
-WORKDIR $GOPATH/src/github.com/amacneil/dbmate
+COPY . $GOPATH/src/github.com/turnitin/dbmate
+WORKDIR $GOPATH/src/github.com/turnitin/dbmate
 
 # build
 RUN go install -v ./cmd/dbmate

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/amacneil/dbmate",
+	"ImportPath": "github.com/turnitin/dbmate",
 	"GoVersion": "go1.6",
 	"GodepVersion": "v74",
 	"Deps": [

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	$(DC) run dbmate go test -v $(PACKAGES)
 
 build: clean
-	$(DC) run -e GOARCH=386   dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-i386 ./cmd/dbmate
-	$(DC) run -e GOARCH=amd64 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-amd64 ./cmd/dbmate
-	# musl target does not support sqlite
-	$(DC) run -e GOARCH=amd64 -e CGO_ENABLED=0 dbmate go build $(BUILD_FLAGS) -o dist/dbmate-linux-musl-amd64 ./cmd/dbmate
+	$(DC) run dbmate gox --output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -cgo -ldflags="-s" -osarch="linux/386" -osarch="linux/amd64" ./cmd/dbmate
+	# neither musl (alpine) nor darwin support cgo for sqlite driver because they
+	# use different C libraries.
+	$(DC) run dbmate gox --output "dist/{{.Dir}}-{{.OS}}-{{.Arch}}-nocgo" -ldflags="-s" -osarch="linux/amd64" -osarch="darwin/amd64" ./cmd/dbmate

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ container:
 	$(DC) up -d
 
 lint:
+	$(DC) run dbmate python lint-gofmt.py
 	$(DC) run dbmate golint -set_exit_status $(PACKAGES)
 	$(DC) run dbmate go vet $(PACKAGES)
 	$(DC) run dbmate errcheck $(PACKAGES)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Dbmate
 
-[![Build Status](https://travis-ci.org/amacneil/dbmate.svg?branch=master)](https://travis-ci.org/amacneil/dbmate)
-[![Go Report Card](https://goreportcard.com/badge/github.com/amacneil/dbmate)](https://goreportcard.com/report/github.com/amacneil/dbmate)
-[![GitHub Release](https://img.shields.io/github/release/amacneil/dbmate.svg)](https://github.com/amacneil/dbmate/releases)
+This project was forked from [amacneil/dbmate](https://github.com/amacneil/dbmate)
+Note that this README still needs to be updated to reflect various changes (especially with regard to homebrew and releases).
+
+[![Build Status](https://travis-ci.org/turnitin/dbmate.svg?branch=master)](https://travis-ci.org/turnitin/dbmate)
+[![Go Report Card](https://goreportcard.com/badge/github.com/turnitin/dbmate)](https://goreportcard.com/report/github.com/turnitin/dbmate)
+[![GitHub Release](https://img.shields.io/github/release/turnitin/dbmate.svg)](https://github.com/turnitin/dbmate/releases)
 [![Documentation](https://readthedocs.org/projects/dbmate/badge/)](http://dbmate.readthedocs.org/)
 
 Dbmate is a database migration tool, to keep your database schema in sync across multiple developers and your production servers.
@@ -66,7 +69,7 @@ $ heroku run bin/dbmate-heroku up
 Dbmate can be installed directly using `go get`:
 
 ```sh
-$ go get -u github.com/amacneil/dbmate
+$ go get -u github.com/turnitin/dbmate
 ```
 
 ## Commands
@@ -244,7 +247,7 @@ Why another database schema migration tool? Dbmate was inspired by many other to
 
 > :eight_pointed_black_star: In theory these tools could be used with other languages, but a Go development environment is required because binary builds are not provided.
 
-*If you notice any inaccuracies in this table, please [propose a change](https://github.com/amacneil/dbmate/edit/master/README.md).*
+*If you notice any inaccuracies in this table, please [propose a change](https://github.com/turnitin/dbmate/edit/master/README.md).*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Rolling back: 20151127184807_create_users_table.sql
 The following command line options are available with all commands. You must use command line arguments in the order `dbmate [global options] command [command options]`.
 
 * `--migrations-dir, -d "./db/migrations"` - where to keep the migration files.
+* `--project, -p "project-name"` - a name under which to associate the set of migrations. defaults to 'default'
 * `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
 
 For example, before running your test suite, you may wish to drop and recreate the test database. One easy way to do this is to store your test database connection URL in the `TEST_DATABASE_URL` environment variable:

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -40,6 +40,11 @@ func NewApp() *cli.App {
 			Value: "DATABASE_URL",
 			Usage: "specify an environment variable containing the database URL",
 		},
+		cli.StringFlag{
+			Name: "project, p",
+			Value: "default",
+			Usage: "specify a name to associate with the migration set",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -113,6 +118,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		}
 		db := dbmate.NewDB(u)
 		db.MigrationsDir = c.GlobalString("migrations-dir")
+		db.Project = c.GlobalString("project")
 
 		return f(db, c)
 	}

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/amacneil/dbmate"
+	"github.com/turnitin/dbmate"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
 )

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/turnitin/dbmate"
 	"github.com/joho/godotenv"
+	"github.com/turnitin/dbmate"
 	"github.com/urfave/cli"
 )
 
@@ -41,7 +41,7 @@ func NewApp() *cli.App {
 			Usage: "specify an environment variable containing the database URL",
 		},
 		cli.StringFlag{
-			Name: "project, p",
+			Name:  "project, p",
 			Value: "default",
 			Usage: "specify a name to associate with the migration set",
 		},

--- a/db.go
+++ b/db.go
@@ -15,10 +15,14 @@ import (
 // DefaultMigrationsDir specifies default directory to find migration files
 var DefaultMigrationsDir = "./db/migrations"
 
+// DefaultProject specifies the default name to associate with the migrations
+var DefaultProject = "default"
+
 // DB allows dbmate actions to be performed on a specified database
 type DB struct {
 	DatabaseURL   *url.URL
 	MigrationsDir string
+	Project       string
 }
 
 // NewDB initializes a new dbmate database
@@ -26,6 +30,7 @@ func NewDB(databaseURL *url.URL) *DB {
 	return &DB{
 		DatabaseURL:   databaseURL,
 		MigrationsDir: DefaultMigrationsDir,
+		Project:       DefaultProject,
 	}
 }
 
@@ -168,7 +173,7 @@ func (db *DB) Migrate() error {
 	}
 	defer mustClose(sqlDB)
 
-	applied, err := drv.SelectMigrations(sqlDB, -1)
+	applied, err := drv.SelectMigrations(sqlDB, -1, db.Project)
 	if err != nil {
 		return err
 	}
@@ -195,7 +200,7 @@ func (db *DB) Migrate() error {
 			}
 
 			// record migration
-			if err := drv.InsertMigration(tx, ver); err != nil {
+			if err := drv.InsertMigration(tx, ver, db.Project); err != nil {
 				return err
 			}
 
@@ -304,7 +309,7 @@ func (db *DB) Rollback() error {
 	}
 	defer mustClose(sqlDB)
 
-	applied, err := drv.SelectMigrations(sqlDB, 1)
+	applied, err := drv.SelectMigrations(sqlDB, 1, db.Project)
 	if err != nil {
 		return err
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   dbmate:
     build: .
     volumes:
-      - .:/go/src/github.com/amacneil/dbmate
+      - .:/go/src/github.com/turnitin/dbmate
     depends_on:
       mysql:
         condition: service_healthy

--- a/driver.go
+++ b/driver.go
@@ -13,8 +13,8 @@ type Driver interface {
 	CreateDatabase(*url.URL) error
 	DropDatabase(*url.URL) error
 	CreateMigrationsTable(*sql.DB) error
-	SelectMigrations(*sql.DB, int) (map[string]bool, error)
-	InsertMigration(Transaction, string) error
+	SelectMigrations(*sql.DB, int, string) (map[string]bool, error)
+	InsertMigration(Transaction, string, string) error
 	DeleteMigration(Transaction, string) error
 }
 

--- a/lint-gofmt.py
+++ b/lint-gofmt.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import glob
+import subprocess
+
+files = []
+# All go files in these directories will be run through gofmt
+for p in ['*.go', 'cmd/dbmate/*.go']:
+    files.extend(glob.glob(p))
+
+
+exit_status = 0
+for filename in files:
+    if filename.endswith('.go'):
+        try:
+            out = subprocess.check_output(['gofmt', '-s', '-l', filename])
+            if out != '':
+                print out,
+                exit_status = 1
+        except subprocess.CalledProcessError:
+            exit_status = 1
+
+if exit_status != 0:
+    print 'Reformat the files listed above with "gofmt -s -w" and try again.'
+    exit(exit_status)
+
+print 'All files pass gofmt.'
+exit(0)

--- a/mysql.go
+++ b/mysql.go
@@ -110,18 +110,28 @@ func (drv MySQLDriver) DatabaseExists(u *url.URL) (bool, error) {
 func (drv MySQLDriver) CreateMigrationsTable(db *sql.DB) error {
 	_, err := db.Exec(`create table if not exists schema_migrations (
 		version varchar(255) primary key)`)
+	if err != nil {
+		return err
+	}
+
+	// Add the project column if it doesn't already exist.
+	_, err = db.Exec(`select project from schema_migrations limit 1`)
+	if err != nil {
+		_, err = db.Exec(`alter table schema_migrations
+			add column project varchar(255) default 'default'`)
+	}
 
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	query := "select version from schema_migrations order by version desc"
+func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int, project string) (map[string]bool, error) {
+	query := "select version from schema_migrations where project = ? order by version desc"
 	if limit >= 0 {
 		query = fmt.Sprintf("%s limit %d", query, limit)
 	}
-	rows, err := db.Query(query)
+	rows, err := db.Query(query, project)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +152,8 @@ func (drv MySQLDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool,
 }
 
 // InsertMigration adds a new migration record
-func (drv MySQLDriver) InsertMigration(db Transaction, version string) error {
-	_, err := db.Exec("insert into schema_migrations (version) values (?)", version)
+func (drv MySQLDriver) InsertMigration(db Transaction, version string, project string) error {
+	_, err := db.Exec("insert into schema_migrations (version, project) values (?, ?)", version, project)
 
 	return err
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -158,18 +158,29 @@ func TestMySQLSelectMigrations(t *testing.T) {
 		values ('abc2'), ('abc1'), ('abc3')`)
 	require.Nil(t, err)
 
-	migrations, err := drv.SelectMigrations(db, -1)
+	migrations, err := drv.SelectMigrations(db, -1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc1"])
 	require.Equal(t, true, migrations["abc2"])
 	require.Equal(t, true, migrations["abc2"])
 
 	// test limit param
-	migrations, err = drv.SelectMigrations(db, 1)
+	migrations, err = drv.SelectMigrations(db, 1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc3"])
 	require.Equal(t, false, migrations["abc1"])
 	require.Equal(t, false, migrations["abc2"])
+
+	// test different project
+	_, err = db.Exec(`insert into schema_migrations (version, project)
+		values ('bcd1', 'app2')`)
+	require.Nil(t, err)
+	migrations, err = drv.SelectMigrations(db, -1, "app2")
+	require.Nil(t, err)
+	require.Equal(t, true, migrations["bcd1"])
+	require.Equal(t, false, migrations["abc1"])
+	require.Equal(t, false, migrations["abc2"])
+	require.Equal(t, false, migrations["abc3"])
 }
 
 func TestMySQLInsertMigration(t *testing.T) {
@@ -186,7 +197,7 @@ func TestMySQLInsertMigration(t *testing.T) {
 	require.Equal(t, 0, count)
 
 	// insert migration
-	err = drv.InsertMigration(db, "abc1")
+	err = drv.InsertMigration(db, "abc1", "default")
 	require.Nil(t, err)
 
 	err = db.QueryRow("select count(*) from schema_migrations where version = 'abc1'").

--- a/postgres.go
+++ b/postgres.go
@@ -83,18 +83,28 @@ func (drv PostgresDriver) DatabaseExists(u *url.URL) (bool, error) {
 func (drv PostgresDriver) CreateMigrationsTable(db *sql.DB) error {
 	_, err := db.Exec(`create table if not exists schema_migrations (
 		version varchar(255) primary key)`)
+	if err != nil {
+		return err
+	}
+
+	// Add the project column if it doesn't already exist.
+	_, err = db.Exec(`select project from schema_migrations limit 1`)
+	if err != nil {
+		_, err = db.Exec(`alter table schema_migrations
+			add column project varchar(255) default 'default'`)
+	}
 
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	query := "select version from schema_migrations order by version desc"
+func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int, project string) (map[string]bool, error) {
+	query := "select version from schema_migrations where project = $1 order by version desc"
 	if limit >= 0 {
 		query = fmt.Sprintf("%s limit %d", query, limit)
 	}
-	rows, err := db.Query(query)
+	rows, err := db.Query(query, project)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +125,8 @@ func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bo
 }
 
 // InsertMigration adds a new migration record
-func (drv PostgresDriver) InsertMigration(db Transaction, version string) error {
-	_, err := db.Exec("insert into schema_migrations (version) values ($1)", version)
+func (drv PostgresDriver) InsertMigration(db Transaction, version string, project string) error {
+	_, err := db.Exec("insert into schema_migrations (version, project) values ($1, $2)", version, project)
 
 	return err
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -119,18 +119,29 @@ func TestSQLiteSelectMigrations(t *testing.T) {
 		values ('abc2'), ('abc1'), ('abc3')`)
 	require.Nil(t, err)
 
-	migrations, err := drv.SelectMigrations(db, -1)
+	migrations, err := drv.SelectMigrations(db, -1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc1"])
 	require.Equal(t, true, migrations["abc2"])
 	require.Equal(t, true, migrations["abc2"])
 
 	// test limit param
-	migrations, err = drv.SelectMigrations(db, 1)
+	migrations, err = drv.SelectMigrations(db, 1, "default")
 	require.Nil(t, err)
 	require.Equal(t, true, migrations["abc3"])
 	require.Equal(t, false, migrations["abc1"])
 	require.Equal(t, false, migrations["abc2"])
+
+	// test different project
+	_, err = db.Exec(`insert into schema_migrations (version, project)
+		values ('bcd1', 'app2')`)
+	require.Nil(t, err)
+	migrations, err = drv.SelectMigrations(db, -1, "app2")
+	require.Nil(t, err)
+	require.Equal(t, true, migrations["bcd1"])
+	require.Equal(t, false, migrations["abc1"])
+	require.Equal(t, false, migrations["abc2"])
+	require.Equal(t, false, migrations["abc3"])
 }
 
 func TestSQLiteInsertMigration(t *testing.T) {
@@ -147,7 +158,7 @@ func TestSQLiteInsertMigration(t *testing.T) {
 	require.Equal(t, 0, count)
 
 	// insert migration
-	err = drv.InsertMigration(db, "abc1")
+	err = drv.InsertMigration(db, "abc1", "default")
 	require.Nil(t, err)
 
 	err = db.QueryRow("select count(*) from schema_migrations where version = 'abc1'").


### PR DESCRIPTION
Running `make build` will produce 4 binaries in the *dist* directory. This change adds darwin (OS X) as a build target.