### PR TITLE
Implement schema dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/dist
 .DS_Store
+/dist
+/testdata/db/schema.sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ FROM golang:1.9 as build
 # required to force cgo (for sqlite driver) with cross compile
 ENV CGO_ENABLED 1
 
+# install database clients
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends mysql-client postgresql-client \
+	&& rm -rf /var/lib/apt/lists/*
+
 # development dependencies
 RUN go get \
 	github.com/golang/lint/golint \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV CGO_ENABLED 1
 
 # install database clients
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends mysql-client postgresql-client \
+	&& apt-get install -y --no-install-recommends \
+		mysql-client \
+		postgresql-client \
+		sqlite3 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # development dependencies

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -31,14 +31,19 @@ func NewApp() *cli.App {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "env, e",
+			Value: "DATABASE_URL",
+			Usage: "specify an environment variable containing the database URL",
+		},
+		cli.StringFlag{
 			Name:  "migrations-dir, d",
 			Value: dbmate.DefaultMigrationsDir,
 			Usage: "specify the directory containing migration files",
 		},
 		cli.StringFlag{
-			Name:  "env, e",
-			Value: "DATABASE_URL",
-			Usage: "specify an environment variable containing the database URL",
+			Name:  "schema-file, s",
+			Value: dbmate.DefaultSchemaFile,
+			Usage: "specify the schema file location",
 		},
 	}
 
@@ -90,7 +95,7 @@ func NewApp() *cli.App {
 		},
 		{
 			Name:  "dump",
-			Usage: "Dump the current database schema to file",
+			Usage: "Write the database schema to disk",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				return db.DumpSchema()
 			}),
@@ -120,6 +125,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		}
 		db := dbmate.New(u)
 		db.MigrationsDir = c.GlobalString("migrations-dir")
+		db.SchemaFile = c.GlobalString("schema-file")
 
 		return f(db, c)
 	}

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -63,14 +63,14 @@ func NewApp() *cli.App {
 			Name:  "create",
 			Usage: "Create database",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.CreateDatabase()
+				return db.Create()
 			}),
 		},
 		{
 			Name:  "drop",
 			Usage: "Drop database (if it exists)",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.DropDatabase()
+				return db.Drop()
 			}),
 		},
 		{

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -49,28 +49,28 @@ func NewApp() *cli.App {
 			Usage:   "Generate a new migration file",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				name := c.Args().First()
-				return db.New(name)
+				return db.NewMigration(name)
 			}),
 		},
 		{
 			Name:  "up",
 			Usage: "Create database (if necessary) and migrate to the latest version",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.Up()
+				return db.CreateAndMigrate()
 			}),
 		},
 		{
 			Name:  "create",
 			Usage: "Create database",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.Create()
+				return db.CreateDatabase()
 			}),
 		},
 		{
 			Name:  "drop",
 			Usage: "Drop database (if it exists)",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				return db.Drop()
+				return db.DropDatabase()
 			}),
 		},
 		{
@@ -86,6 +86,13 @@ func NewApp() *cli.App {
 			Usage:   "Rollback the most recent migration",
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				return db.Rollback()
+			}),
+		},
+		{
+			Name:  "dump",
+			Usage: "Dump the current database schema to file",
+			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				return db.DumpSchema()
 			}),
 		},
 	}
@@ -111,7 +118,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		db := dbmate.NewDB(u)
+		db := dbmate.New(u)
 		db.MigrationsDir = c.GlobalString("migrations-dir")
 
 		return f(db, c)

--- a/cmd/dbmate/main.go
+++ b/cmd/dbmate/main.go
@@ -45,6 +45,10 @@ func NewApp() *cli.App {
 			Value: dbmate.DefaultSchemaFile,
 			Usage: "specify the schema file location",
 		},
+		cli.BoolFlag{
+			Name:  "no-dump-schema",
+			Usage: "don't update the schema file on migrate/rollback",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -124,6 +128,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 			return err
 		}
 		db := dbmate.New(u)
+		db.AutoDumpSchema = !c.GlobalBool("no-dump-schema")
 		db.MigrationsDir = c.GlobalString("migrations-dir")
 		db.SchemaFile = c.GlobalString("schema-file")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
       test: ["CMD", "mysqladmin", "status", "-proot"]
 
   postgres:
-    image: postgres
+    image: postgres:9.6
     healthcheck:
       test: ["CMD", "pg_isready"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         condition: service_healthy
 
   mysql:
-    image: mysql
+    image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: root
     healthcheck:

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -20,17 +20,19 @@ var DefaultSchemaFile = "./db/schema.sql"
 
 // DB allows dbmate actions to be performed on a specified database
 type DB struct {
-	DatabaseURL   *url.URL
-	MigrationsDir string
-	SchemaFile    string
+	AutoDumpSchema bool
+	DatabaseURL    *url.URL
+	MigrationsDir  string
+	SchemaFile     string
 }
 
 // New initializes a new dbmate database
 func New(databaseURL *url.URL) *DB {
 	return &DB{
-		DatabaseURL:   databaseURL,
-		MigrationsDir: DefaultMigrationsDir,
-		SchemaFile:    DefaultSchemaFile,
+		AutoDumpSchema: true,
+		DatabaseURL:    databaseURL,
+		MigrationsDir:  DefaultMigrationsDir,
+		SchemaFile:     DefaultSchemaFile,
 	}
 }
 
@@ -92,6 +94,8 @@ func (db *DB) DumpSchema() error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Writing: %s\n", db.SchemaFile)
 
 	// ensure schema directory exists
 	if err = ensureDir(filepath.Dir(db.SchemaFile)); err != nil {
@@ -230,6 +234,11 @@ func (db *DB) Migrate() error {
 
 	}
 
+	// automatically update schema file, silence errors
+	if db.AutoDumpSchema {
+		_ = db.DumpSchema()
+	}
+
 	return nil
 }
 
@@ -365,6 +374,11 @@ func (db *DB) Rollback() error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// automatically update schema file, silence errors
+	if db.AutoDumpSchema {
+		_ = db.DumpSchema()
 	}
 
 	return nil

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -93,9 +93,8 @@ func (db *DB) DumpSchema() error {
 	}
 
 	// ensure schema directory exists
-	schemaDir := filepath.Dir(db.SchemaFile)
-	if err := os.MkdirAll(schemaDir, 0755); err != nil {
-		return fmt.Errorf("unable to create directory `%s`", schemaDir)
+	if err = ensureDir(filepath.Dir(db.SchemaFile)); err != nil {
+		return err
 	}
 
 	// write schema to file
@@ -114,8 +113,8 @@ func (db *DB) NewMigration(name string) error {
 	name = fmt.Sprintf("%s_%s.sql", timestamp, name)
 
 	// create migrations dir if missing
-	if err := os.MkdirAll(db.MigrationsDir, 0755); err != nil {
-		return fmt.Errorf("unable to create directory `%s`", db.MigrationsDir)
+	if err := ensureDir(db.MigrationsDir); err != nil {
+		return err
 	}
 
 	// check file does not already exist

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -60,8 +60,8 @@ func (db *DB) CreateAndMigrate() error {
 	return db.Migrate()
 }
 
-// CreateDatabase creates the current database
-func (db *DB) CreateDatabase() error {
+// Create creates the current database
+func (db *DB) Create() error {
 	drv, err := db.GetDriver()
 	if err != nil {
 		return err
@@ -70,8 +70,8 @@ func (db *DB) CreateDatabase() error {
 	return drv.CreateDatabase(db.DatabaseURL)
 }
 
-// DropDatabase drops the current database (if it exists)
-func (db *DB) DropDatabase() error {
+// Drop drops the current database (if it exists)
+func (db *DB) Drop() error {
 	drv, err := db.GetDriver()
 	if err != nil {
 		return err

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -15,17 +15,22 @@ import (
 // DefaultMigrationsDir specifies default directory to find migration files
 var DefaultMigrationsDir = "./db/migrations"
 
+// DefaultSchemaFile specifies default location for schema.sql
+var DefaultSchemaFile = "./db/schema.sql"
+
 // DB allows dbmate actions to be performed on a specified database
 type DB struct {
 	DatabaseURL   *url.URL
 	MigrationsDir string
+	SchemaFile    string
 }
 
-// NewDB initializes a new dbmate database
-func NewDB(databaseURL *url.URL) *DB {
+// New initializes a new dbmate database
+func New(databaseURL *url.URL) *DB {
 	return &DB{
 		DatabaseURL:   databaseURL,
 		MigrationsDir: DefaultMigrationsDir,
+		SchemaFile:    DefaultSchemaFile,
 	}
 }
 
@@ -34,8 +39,8 @@ func (db *DB) GetDriver() (Driver, error) {
 	return GetDriver(db.DatabaseURL.Scheme)
 }
 
-// Up creates the database (if necessary) and runs migrations
-func (db *DB) Up() error {
+// CreateAndMigrate creates the database (if necessary) and runs migrations
+func (db *DB) CreateAndMigrate() error {
 	drv, err := db.GetDriver()
 	if err != nil {
 		return err
@@ -55,8 +60,8 @@ func (db *DB) Up() error {
 	return db.Migrate()
 }
 
-// Create creates the current database
-func (db *DB) Create() error {
+// CreateDatabase creates the current database
+func (db *DB) CreateDatabase() error {
 	drv, err := db.GetDriver()
 	if err != nil {
 		return err
@@ -65,8 +70,8 @@ func (db *DB) Create() error {
 	return drv.CreateDatabase(db.DatabaseURL)
 }
 
-// Drop drops the current database (if it exists)
-func (db *DB) Drop() error {
+// DropDatabase drops the current database (if it exists)
+func (db *DB) DropDatabase() error {
 	drv, err := db.GetDriver()
 	if err != nil {
 		return err
@@ -75,10 +80,20 @@ func (db *DB) Drop() error {
 	return drv.DropDatabase(db.DatabaseURL)
 }
 
+// DumpSchema writes the current database schema to a file
+func (db *DB) DumpSchema() error {
+	drv, err := db.GetDriver()
+	if err != nil {
+		return err
+	}
+
+	return drv.DumpSchema(db.DatabaseURL)
+}
+
 const migrationTemplate = "-- migrate:up\n\n\n-- migrate:down\n\n"
 
-// New creates a new migration file
-func (db *DB) New(name string) error {
+// NewMigration creates a new migration file
+func (db *DB) NewMigration(name string) error {
 	// new migration name
 	timestamp := time.Now().UTC().Format("20060102150405")
 	if name == "" {

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -82,12 +82,13 @@ func (db *DB) Drop() error {
 
 // DumpSchema writes the current database schema to a file
 func (db *DB) DumpSchema() error {
-	drv, err := db.GetDriver()
+	drv, sqlDB, err := db.openDatabaseForMigration()
 	if err != nil {
 		return err
 	}
+	defer mustClose(sqlDB)
 
-	schema, err := drv.DumpSchema(db.DatabaseURL)
+	schema, err := drv.DumpSchema(db.DatabaseURL, sqlDB)
 	if err != nil {
 		return err
 	}

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -87,7 +87,19 @@ func (db *DB) DumpSchema() error {
 		return err
 	}
 
-	return drv.DumpSchema(db.DatabaseURL)
+	schema, err := drv.DumpSchema(db.DatabaseURL)
+	if err != nil {
+		return err
+	}
+
+	// ensure schema directory exists
+	schemaDir := filepath.Dir(db.SchemaFile)
+	if err := os.MkdirAll(schemaDir, 0755); err != nil {
+		return fmt.Errorf("unable to create directory `%s`", schemaDir)
+	}
+
+	// write schema to file
+	return ioutil.WriteFile(db.SchemaFile, schema, 0644)
 }
 
 const migrationTemplate = "-- migrate:up\n\n\n-- migrate:down\n\n"

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -23,7 +23,7 @@ func newTestDB(t *testing.T, u *url.URL) *DB {
 		require.Nil(t, err)
 	}
 
-	return NewDB(u)
+	return New(u)
 }
 
 func testURLs(t *testing.T) []*url.URL {
@@ -38,9 +38,9 @@ func testMigrateURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop and recreate database
-	err := db.Drop()
+	err := db.DropDatabase()
 	require.Nil(t, err)
-	err = db.Create()
+	err = db.CreateDatabase()
 	require.Nil(t, err)
 
 	// migrate
@@ -73,11 +73,11 @@ func testUpURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop database
-	err := db.Drop()
+	err := db.DropDatabase()
 	require.Nil(t, err)
 
 	// create and migrate
-	err = db.Up()
+	err = db.CreateAndMigrate()
 	require.Nil(t, err)
 
 	// verify results
@@ -106,9 +106,9 @@ func testRollbackURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop, recreate, and migrate database
-	err := db.Drop()
+	err := db.DropDatabase()
 	require.Nil(t, err)
-	err = db.Create()
+	err = db.CreateDatabase()
 	require.Nil(t, err)
 	err = db.Migrate()
 	require.Nil(t, err)

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -1,6 +1,7 @@
 package dbmate
 
 import (
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -24,6 +25,43 @@ func newTestDB(t *testing.T, u *url.URL) *DB {
 	}
 
 	return New(u)
+}
+
+func TestDumpSchema(t *testing.T) {
+	u := postgresTestURL(t)
+	db := newTestDB(t, u)
+
+	// create custom schema file
+	dir, err := ioutil.TempDir("", "dbmate")
+	require.Nil(t, err)
+	defer func() {
+		err := os.RemoveAll(dir)
+		require.Nil(t, err)
+	}()
+
+	// create schema.sql in subdirectory to test creating directory
+	db.SchemaFile = filepath.Join(dir, "/schema/schema.sql")
+
+	// drop database
+	err = db.Drop()
+	require.Nil(t, err)
+
+	// create and migrate
+	err = db.CreateAndMigrate()
+	require.Nil(t, err)
+
+	// schema.sql should not exist
+	_, err = os.Stat(db.SchemaFile)
+	require.True(t, os.IsNotExist(err))
+
+	// dump schema
+	err = db.DumpSchema()
+	require.Nil(t, err)
+
+	// verify schema
+	schema, err := ioutil.ReadFile(db.SchemaFile)
+	require.Nil(t, err)
+	require.Contains(t, string(schema), "-- PostgreSQL database dump")
 }
 
 func testURLs(t *testing.T) []*url.URL {

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -38,9 +38,9 @@ func testMigrateURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop and recreate database
-	err := db.DropDatabase()
+	err := db.Drop()
 	require.Nil(t, err)
-	err = db.CreateDatabase()
+	err = db.Create()
 	require.Nil(t, err)
 
 	// migrate
@@ -73,7 +73,7 @@ func testUpURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop database
-	err := db.DropDatabase()
+	err := db.Drop()
 	require.Nil(t, err)
 
 	// create and migrate
@@ -106,9 +106,9 @@ func testRollbackURL(t *testing.T, u *url.URL) {
 	db := newTestDB(t, u)
 
 	// drop, recreate, and migrate database
-	err := db.DropDatabase()
+	err := db.Drop()
 	require.Nil(t, err)
-	err = db.CreateDatabase()
+	err = db.Create()
 	require.Nil(t, err)
 	err = db.Migrate()
 	require.Nil(t, err)

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -12,7 +12,7 @@ type Driver interface {
 	DatabaseExists(*url.URL) (bool, error)
 	CreateDatabase(*url.URL) error
 	DropDatabase(*url.URL) error
-	DumpSchema(*url.URL) error
+	DumpSchema(*url.URL) ([]byte, error)
 	CreateMigrationsTable(*sql.DB) error
 	SelectMigrations(*sql.DB, int) (map[string]bool, error)
 	InsertMigration(Transaction, string) error

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -12,6 +12,7 @@ type Driver interface {
 	DatabaseExists(*url.URL) (bool, error)
 	CreateDatabase(*url.URL) error
 	DropDatabase(*url.URL) error
+	DumpSchema(*url.URL) error
 	CreateMigrationsTable(*sql.DB) error
 	SelectMigrations(*sql.DB, int) (map[string]bool, error)
 	InsertMigration(Transaction, string) error

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -12,7 +12,7 @@ type Driver interface {
 	DatabaseExists(*url.URL) (bool, error)
 	CreateDatabase(*url.URL) error
 	DropDatabase(*url.URL) error
-	DumpSchema(*url.URL) ([]byte, error)
+	DumpSchema(*url.URL, *sql.DB) ([]byte, error)
 	CreateMigrationsTable(*sql.DB) error
 	SelectMigrations(*sql.DB, int) (map[string]bool, error)
 	InsertMigration(Transaction, string) error

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -89,7 +89,7 @@ func (drv MySQLDriver) DropDatabase(u *url.URL) error {
 // DumpSchema returns the current database schema
 func (drv MySQLDriver) DumpSchema(u *url.URL) ([]byte, error) {
 	// generate CLI arguments
-	args := []string{"--no-data", "--skip-comments"}
+	args := []string{"--no-data", "--skip-comments", "--skip-add-drop-table"}
 
 	if hostname := u.Hostname(); hostname != "" {
 		args = append(args, "--host="+hostname)

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -88,8 +88,8 @@ func (drv MySQLDriver) DropDatabase(u *url.URL) error {
 }
 
 // DumpSchema writes the current database schema to a file
-func (drv MySQLDriver) DumpSchema(u *url.URL) error {
-	return errors.New("not implemented")
+func (drv MySQLDriver) DumpSchema(u *url.URL) ([]byte, error) {
+	return nil, errors.New("not implemented")
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -103,7 +103,6 @@ func mysqldumpArgs(u *url.URL) []string {
 	}
 	// mysql recommands against using environment variables to supply password
 	// https://dev.mysql.com/doc/refman/5.7/en/password-security-user.html
-	// a potentially more secure way to do this would be to write a temporary file
 	if password, set := u.User.Password(); set {
 		args = append(args, "--password="+password)
 	}

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -2,6 +2,7 @@ package dbmate
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -84,6 +85,11 @@ func (drv MySQLDriver) DropDatabase(u *url.URL) error {
 		quoteIdentifier(name)))
 
 	return err
+}
+
+// DumpSchema writes the current database schema to a file
+func (drv MySQLDriver) DumpSchema(u *url.URL) error {
+	return errors.New("not implemented")
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -110,15 +110,15 @@ func TestMySQLDumpSchema(t *testing.T) {
 	schema, err := drv.DumpSchema(u, db)
 	require.Nil(t, err)
 	require.Contains(t, string(schema), "CREATE TABLE `schema_migrations`")
-	require.Contains(t, string(schema), "\n--\n"+
-		"-- Dumping routines for database 'dbmate'\n--\n\n"+
-		"--\n-- Dbmate schema migrations\n--\n\n"+
+	require.Contains(t, string(schema), "\n-- Dump completed\n\n"+
+		"--\n"+
+		"-- Dbmate schema migrations\n"+
+		"--\n\n"+
 		"LOCK TABLES `schema_migrations` WRITE;\n"+
-		"INSERT INTO `schema_migrations` VALUES\n"+
+		"INSERT INTO `schema_migrations` (version) VALUES\n"+
 		"  ('abc1'),\n"+
 		"  ('abc2');\n"+
-		"UNLOCK TABLES;\n\n"+
-		"/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;\n")
+		"UNLOCK TABLES;\n")
 
 	// DumpSchema should return error if command fails
 	u.Path = "/fakedb"

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -90,6 +90,30 @@ func TestMySQLCreateDropDatabase(t *testing.T) {
 	}()
 }
 
+func TestMySQLDumpSchema(t *testing.T) {
+	drv := MySQLDriver{}
+	u := mySQLTestURL(t)
+
+	// drop any existing database
+	err := drv.DropDatabase(u)
+	require.Nil(t, err)
+
+	// DumpSchema should fail
+	schema, err := drv.DumpSchema(u)
+	require.Nil(t, schema)
+	require.NotNil(t, err)
+	require.Equal(t, "mysqldump: Got error: 1049: \"Unknown database 'dbmate'\" when selecting the database", err.Error())
+
+	// create database
+	db := prepTestMySQLDB(t)
+	defer mustClose(db)
+
+	// DumpSchema should return schema
+	schema, err = drv.DumpSchema(u)
+	require.Nil(t, err)
+	require.Contains(t, string(schema), "SET SQL_MODE=@OLD_SQL_MODE")
+}
+
 func TestMySQLDatabaseExists(t *testing.T) {
 	drv := MySQLDriver{}
 	u := mySQLTestURL(t)

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -103,18 +103,20 @@ func TestMySQLDumpSchema(t *testing.T) {
 	// insert migration
 	err = drv.InsertMigration(db, "abc1")
 	require.Nil(t, err)
+	err = drv.InsertMigration(db, "abc2")
+	require.Nil(t, err)
 
 	// DumpSchema should return schema
 	schema, err := drv.DumpSchema(u, db)
 	require.Nil(t, err)
 	require.Contains(t, string(schema), "CREATE TABLE `schema_migrations`")
-	require.Contains(t, string(schema), "\n"+
-		"/*!40101 SET character_set_client = @saved_cs_client */;\n\n"+
-		"--\n-- Dbmate applied migrations\n--\n\n"+
+	require.Contains(t, string(schema), "\n--\n"+
+		"-- Dumping routines for database 'dbmate'\n--\n\n"+
+		"--\n-- Dbmate schema migrations\n--\n\n"+
 		"LOCK TABLES `schema_migrations` WRITE;\n"+
-		"/*!40000 ALTER TABLE `schema_migrations` DISABLE KEYS */;\n"+
-		"INSERT INTO `schema_migrations` VALUES ('abc1');\n"+
-		"/*!40000 ALTER TABLE `schema_migrations` ENABLE KEYS */;\n"+
+		"INSERT INTO `schema_migrations` VALUES\n"+
+		"  ('abc1'),\n"+
+		"  ('abc2');\n"+
 		"UNLOCK TABLES;\n\n"+
 		"/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;\n")
 

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -1,9 +1,11 @@
 package dbmate
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"net/url"
+	"os/exec"
 
 	"github.com/lib/pq"
 )
@@ -57,6 +59,24 @@ func (drv PostgresDriver) DropDatabase(u *url.URL) error {
 		pq.QuoteIdentifier(name)))
 
 	return err
+}
+
+// DumpSchema writes the current database schema to a file
+func (drv PostgresDriver) DumpSchema(u *url.URL) error {
+	fmt.Println("running pg_dump...")
+	cmd := exec.Command("pg_dump", "-Fp", "--no-acl", "--no-owner", u.String())
+	var out bytes.Buffer
+	var errout bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errout
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error running pg_dump: %s", errout.String())
+	}
+	fmt.Printf("pg_dump output: %q\n", out.String())
+	fmt.Printf("pg_dump errout: %q\n", errout.String())
+
+	return fmt.Errorf("error: not implemented")
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -1,12 +1,9 @@
 package dbmate
 
 import (
-	"bytes"
 	"database/sql"
 	"fmt"
 	"net/url"
-	"os/exec"
-	"strings"
 
 	"github.com/lib/pq"
 )
@@ -62,19 +59,10 @@ func (drv PostgresDriver) DropDatabase(u *url.URL) error {
 	return err
 }
 
-// DumpSchema writes the current database schema to a file
+// DumpSchema returns the current database schema
 func (drv PostgresDriver) DumpSchema(u *url.URL) ([]byte, error) {
-	var stdout bytes.Buffer
-	cmd := exec.Command("pg_dump", "--format=plain", "--encoding=UTF8", "--schema-only",
+	return runCommand("pg_dump", "--format=plain", "--encoding=UTF8", "--schema-only",
 		"--no-acl", "--no-owner", u.String())
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stdout
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("error: %s", strings.TrimSpace(stdout.String()))
-	}
-
-	return stdout.Bytes(), nil
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -84,8 +84,7 @@ func TestPostgresDumpSchema(t *testing.T) {
 	schema, err := drv.DumpSchema(u)
 	require.Nil(t, schema)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "error: pg_dump:")
-	require.Contains(t, err.Error(), "database \"dbmate\" does not exist")
+	require.Equal(t, "pg_dump: [archiver (db)] connection to database \"dbmate\" failed: FATAL:  database \"dbmate\" does not exist", err.Error())
 
 	// create database
 	db := prepTestPostgresDB(t)

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -91,6 +91,7 @@ func TestPostgresDumpSchema(t *testing.T) {
 	// DumpSchema should return schema
 	schema, err := drv.DumpSchema(u, db)
 	require.Nil(t, err)
+	require.Contains(t, string(schema), "CREATE TABLE schema_migrations")
 	require.Contains(t, string(schema), "\n--\n"+
 		"-- PostgreSQL database dump complete\n"+
 		"--\n\n\n"+

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -85,14 +85,17 @@ func TestPostgresDumpSchema(t *testing.T) {
 	// insert migration
 	err = drv.InsertMigration(db, "abc1")
 	require.Nil(t, err)
+	err = drv.InsertMigration(db, "abc2")
+	require.Nil(t, err)
 
 	// DumpSchema should return schema
 	schema, err := drv.DumpSchema(u, db)
 	require.Nil(t, err)
 	require.Contains(t, string(schema), "-- PostgreSQL database dump")
-	require.Contains(t, string(schema), "\n\n--\n-- Dbmate applied migrations\n--\n\n"+
+	require.Contains(t, string(schema), "\n\n--\n-- Dbmate schema migrations\n--\n\n"+
 		"COPY schema_migrations (version) FROM stdin;\n"+
 		"abc1\n"+
+		"abc2\n"+
 		"\\.\n")
 
 	// DumpSchema should return error if command fails

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -72,6 +72,31 @@ func TestPostgresCreateDropDatabase(t *testing.T) {
 	}()
 }
 
+func TestPostgresDumpSchema(t *testing.T) {
+	drv := PostgresDriver{}
+	u := postgresTestURL(t)
+
+	// drop any existing database
+	err := drv.DropDatabase(u)
+	require.Nil(t, err)
+
+	// DumpSchema should fail
+	schema, err := drv.DumpSchema(u)
+	require.Nil(t, schema)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "error: pg_dump:")
+	require.Contains(t, err.Error(), "database \"dbmate\" does not exist")
+
+	// create database
+	db := prepTestPostgresDB(t)
+	defer mustClose(db)
+
+	// DumpSchema should return schema
+	schema, err = drv.DumpSchema(u)
+	require.Nil(t, err)
+	require.Contains(t, string(schema), "-- PostgreSQL database dump")
+}
+
 func TestPostgresDatabaseExists(t *testing.T) {
 	drv := PostgresDriver{}
 	u := postgresTestURL(t)

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -91,12 +91,15 @@ func TestPostgresDumpSchema(t *testing.T) {
 	// DumpSchema should return schema
 	schema, err := drv.DumpSchema(u, db)
 	require.Nil(t, err)
-	require.Contains(t, string(schema), "-- PostgreSQL database dump")
-	require.Contains(t, string(schema), "\n\n--\n-- Dbmate schema migrations\n--\n\n"+
-		"COPY schema_migrations (version) FROM stdin;\n"+
-		"abc1\n"+
-		"abc2\n"+
-		"\\.\n")
+	require.Contains(t, string(schema), "\n--\n"+
+		"-- PostgreSQL database dump complete\n"+
+		"--\n\n\n"+
+		"--\n"+
+		"-- Dbmate schema migrations\n"+
+		"--\n\n"+
+		"INSERT INTO schema_migrations (version) VALUES\n"+
+		"    ('abc1'),\n"+
+		"    ('abc2');\n")
 
 	// DumpSchema should return error if command fails
 	u.Path = "/fakedb"

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -57,7 +57,7 @@ func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
 	return os.Remove(path)
 }
 
-// DumpSchema writes the current database schema to a file
+// DumpSchema returns the current database schema
 func (drv SQLiteDriver) DumpSchema(u *url.URL) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -58,7 +58,7 @@ func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
 }
 
 // DumpSchema returns the current database schema
-func (drv SQLiteDriver) DumpSchema(u *url.URL) ([]byte, error) {
+func (drv SQLiteDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -77,8 +77,8 @@ func (drv SQLiteDriver) DatabaseExists(u *url.URL) (bool, error) {
 
 // CreateMigrationsTable creates the schema_migrations table
 func (drv SQLiteDriver) CreateMigrationsTable(db *sql.DB) error {
-	_, err := db.Exec(`create table if not exists schema_migrations (
-		version varchar(255) primary key)`)
+	_, err := db.Exec("create table if not exists schema_migrations " +
+		"(version varchar(255) primary key)")
 
 	return err
 }

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -58,8 +58,8 @@ func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
 }
 
 // DumpSchema writes the current database schema to a file
-func (drv SQLiteDriver) DumpSchema(u *url.URL) error {
-	return errors.New("not implemented")
+func (drv SQLiteDriver) DumpSchema(u *url.URL) ([]byte, error) {
+	return nil, errors.New("not implemented")
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -2,6 +2,7 @@ package dbmate
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -54,6 +55,11 @@ func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
 	}
 
 	return os.Remove(path)
+}
+
+// DumpSchema writes the current database schema to a file
+func (drv SQLiteDriver) DumpSchema(u *url.URL) error {
+	return errors.New("not implemented")
 }
 
 // DatabaseExists determines whether the database exists

--- a/pkg/dbmate/utils.go
+++ b/pkg/dbmate/utils.go
@@ -1,8 +1,12 @@
 package dbmate
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"net/url"
+	"os/exec"
+	"strings"
 )
 
 // databaseName returns the database name from a URL
@@ -19,4 +23,25 @@ func mustClose(c io.Closer) {
 	if err := c.Close(); err != nil {
 		panic(err)
 	}
+}
+
+// runCommand runs a command and returns the stdout if successful
+func runCommand(name string, args ...string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// return stderr if available
+		if s := strings.TrimSpace(stderr.String()); s != "" {
+			return nil, errors.New(s)
+		}
+
+		// otherwise return error
+		return nil, err
+	}
+
+	// return stdout
+	return stdout.Bytes(), nil
 }

--- a/pkg/dbmate/utils.go
+++ b/pkg/dbmate/utils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"unicode"
 )
 
 // databaseName returns the database name from a URL
@@ -79,8 +80,13 @@ func trimLeadingSQLComments(data []byte) ([]byte, error) {
 			continue
 		}
 
-		// header section is over, copy bytes to output buffer
+		// header section is over
 		preamble = false
+
+		// trim trailing whitespace
+		line = bytes.TrimRightFunc(line, unicode.IsSpace)
+
+		// copy bytes to output buffer
 		if _, err := out.Write(line); err != nil {
 			return nil, err
 		}

--- a/pkg/dbmate/utils.go
+++ b/pkg/dbmate/utils.go
@@ -3,8 +3,10 @@ package dbmate
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -19,10 +21,20 @@ func databaseName(u *url.URL) string {
 	return name
 }
 
+// mustClose ensures a stream is closed
 func mustClose(c io.Closer) {
 	if err := c.Close(); err != nil {
 		panic(err)
 	}
+}
+
+// ensureDir creates a directory if it does not already exist
+func ensureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("unable to create directory `%s`", dir)
+	}
+
+	return nil
 }
 
 // runCommand runs a command and returns the stdout if successful

--- a/pkg/dbmate/utils_test.go
+++ b/pkg/dbmate/utils_test.go
@@ -22,3 +22,14 @@ func TestDatabaseName_Empty(t *testing.T) {
 	name := databaseName(u)
 	require.Equal(t, "", name)
 }
+
+func TestTrimLeadingSQLComments(t *testing.T) {
+	in := "--\n" +
+		"-- foo\n\n" +
+		"-- bar\n\n" +
+		"real stuff\n" +
+		"-- end\n"
+	out, err := trimLeadingSQLComments([]byte(in))
+	require.Nil(t, err)
+	require.Equal(t, "real stuff\n-- end\n", string(out))
+}


### PR DESCRIPTION
Implements a `dbmate dump` command to write the database schema to a file.

The intent is for this file to be checked in to the codebase, similar to Rails' `schema.rb` (or `structure.sql`) file. This allows developers to share a single file documenting the database schema, and makes it considerably easier to review PRs which add (or change) migrations.

TODO:

* [x] PostgreSQL support
* [x] MySQL support
* [x] SQLite support
* [x] Pre-fill `schema_migrations` table in sql dump
* [x] Allow custom schema.sql file location
* [x] Dump schema by default when migrating, with cli flag to opt out

Closes https://github.com/amacneil/dbmate/issues/5