### PR TITLE
Add cgo build constraint for sqlite support

### DIFF
--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -19,6 +19,13 @@ type Driver interface {
 	DeleteMigration(Transaction, string) error
 }
 
+var drivers = map[string]Driver{}
+
+// RegisterDriver registers a driver for a URL scheme
+func RegisterDriver(drv Driver, scheme string) {
+	drivers[scheme] = drv
+}
+
 // Transaction can represent a database or open transaction
 type Transaction interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
@@ -26,16 +33,11 @@ type Transaction interface {
 
 // GetDriver loads a database driver by name
 func GetDriver(name string) (Driver, error) {
-	switch name {
-	case "mysql":
-		return MySQLDriver{}, nil
-	case "postgres", "postgresql":
-		return PostgresDriver{}, nil
-	case "sqlite", "sqlite3":
-		return SQLiteDriver{}, nil
-	default:
-		return nil, fmt.Errorf("unknown driver: %s", name)
+	if val, ok := drivers[name]; ok {
+		return val, nil
 	}
+
+	return nil, fmt.Errorf("unsupported driver: %s", name)
 }
 
 // GetDriverOpen is a shortcut for GetDriver(u.Scheme).Open(u)

--- a/pkg/dbmate/driver_test.go
+++ b/pkg/dbmate/driver_test.go
@@ -22,6 +22,6 @@ func TestGetDriver_MySQL(t *testing.T) {
 
 func TestGetDriver_Error(t *testing.T) {
 	drv, err := GetDriver("foo")
-	require.Equal(t, "unknown driver: foo", err.Error())
+	require.Equal(t, "unsupported driver: foo", err.Error())
 	require.Nil(t, drv)
 }

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -10,6 +10,10 @@ import (
 	_ "github.com/go-sql-driver/mysql" // mysql driver for database/sql
 )
 
+func init() {
+	RegisterDriver(MySQLDriver{}, "mysql")
+}
+
 // MySQLDriver provides top level database functions
 type MySQLDriver struct {
 }

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -10,6 +10,11 @@ import (
 	"github.com/lib/pq"
 )
 
+func init() {
+	RegisterDriver(PostgresDriver{}, "postgres")
+	RegisterDriver(PostgresDriver{}, "postgresql")
+}
+
 // PostgresDriver provides top level database functions
 type PostgresDriver struct {
 }

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package dbmate
 
 import (
@@ -11,6 +13,11 @@ import (
 
 	_ "github.com/mattn/go-sqlite3" // sqlite driver for database/sql
 )
+
+func init() {
+	RegisterDriver(SQLiteDriver{}, "sqlite")
+	RegisterDriver(SQLiteDriver{}, "sqlite3")
+}
 
 // SQLiteDriver provides top level database functions
 type SQLiteDriver struct {

--- a/pkg/dbmate/sqlite_test.go
+++ b/pkg/dbmate/sqlite_test.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package dbmate
 
 import (


### PR DESCRIPTION
Required to upgrade https://github.com/mattn/go-sqlite3 which does not compile correctly with missing cgo.