### PR TITLE
Add path to schema_migrations insert statement

### DIFF
--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -79,7 +79,7 @@ func postgresSchemaMigrationsDump(db *sql.DB) ([]byte, error) {
 	buf.WriteString("\n--\n-- Dbmate schema migrations\n--\n\n")
 
 	if len(migrations) > 0 {
-		buf.WriteString("INSERT INTO schema_migrations (version) VALUES\n    (" +
+		buf.WriteString("INSERT INTO public.schema_migrations (version) VALUES\n    (" +
 			strings.Join(migrations, "),\n    (") +
 			");\n")
 	}


### PR DESCRIPTION
Currently importing `schema.sql` fails when inserting the current migrations into the `schema_migrations` table.

At the top of the output of pg_dump it adds the line:

```sql
SELECT pg_catalog.set_config('search_path', '', false);
```

Which wipes out the schema `search_path` so every table reference needs to be absolute.