### PR TITLE
Add support for options; transaction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,24 @@ Rolling back: 20151127184807_create_users_table.sql
 Writing: ./db/schema.sql
 ```
 
+### Migration Options
+
+dbmate supports options passed to a migration block in the form of `key:value` pairs. List of supported options:
+
+* `skip_transaction`
+
+#### skip_transaction
+
+`skip_transaction` is useful if you need to run some SQL which cannot be executed from within a transaction. For example, altering an enum type to add a value. Example:
+
+```sql
+-- migrate:up skip_transaction:true
+ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
+ALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';
+```
+
+`skip_transaction` defaults to `false`.
+
 ### Schema File
 
 When you run the `up`, `migrate`, or `rollback` commands, dbmate will automatically create a `./db/schema.sql` file containing a complete representation of your database schema. Dbmate keeps this file up to date for you, so you should not manually edit it.

--- a/README.md
+++ b/README.md
@@ -209,19 +209,19 @@ Writing: ./db/schema.sql
 
 dbmate supports options passed to a migration block in the form of `key:value` pairs. List of supported options:
 
-* `skip_transaction`
+* `transaction`
 
-#### skip_transaction
+#### transaction
 
-`skip_transaction` is useful if you need to run some SQL which cannot be executed from within a transaction. For example, altering an enum type to add a value. Example:
+`transaction` is useful if you need to run some SQL which cannot be executed from within a transaction. For example, you can disable transactions for migrations that alter an enum type to add a value:
 
 ```sql
--- migrate:up skip_transaction:true
+-- migrate:up transaction:false
 ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 ALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';
 ```
 
-`skip_transaction` defaults to `false`.
+`transaction` will default to `true` for if your database supports it.
 
 ### Schema File
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ dbmate supports options passed to a migration block in the form of `key:value` p
 
 #### transaction
 
-`transaction` is useful if you need to run some SQL which cannot be executed from within a transaction. For example, you can disable transactions for migrations that alter an enum type to add a value:
+`transaction` is useful if you need to run some SQL which cannot be executed from within a transaction. For example, in Postgres, you would need to disable transactions for migrations that alter an enum type to add a value:
 
 ```sql
 -- migrate:up transaction:false

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -253,21 +253,29 @@ func (db *DB) Migrate() error {
 
 		fmt.Printf("Applying: %s\n", filename)
 
-		migration, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
+		up, _, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
 		if err != nil {
 			return err
 		}
 
-		// begin transaction
-		err = doTransaction(sqlDB, func(tx Transaction) error {
+		execMigration := func(tx Transaction) error {
 			// run actual migration
-			if _, err := tx.Exec(migration["up"]); err != nil {
+			if _, err := tx.Exec(up.Contents); err != nil {
 				return err
 			}
 
 			// record migration
 			return drv.InsertMigration(tx, ver)
-		})
+		}
+
+		if up.Options.SkipTransaction() {
+			// run outside of transaction
+			err = execMigration(sqlDB)
+		} else {
+			// begin transaction
+			err = doTransaction(sqlDB, execMigration)
+		}
+
 		if err != nil {
 			return err
 		}
@@ -331,43 +339,6 @@ func migrationVersion(filename string) string {
 	return regexp.MustCompile(`^\d+`).FindString(filename)
 }
 
-// parseMigration reads a migration file into a map with up/down keys
-// implementation is similar to regexp.Split()
-func parseMigration(path string) (map[string]string, error) {
-	// read migration file into string
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	contents := string(data)
-
-	// split string on our trigger comment
-	separatorRegexp := regexp.MustCompile(`(?m)^-- migrate:(.*)$`)
-	matches := separatorRegexp.FindAllStringSubmatchIndex(contents, -1)
-
-	migrations := map[string]string{}
-	direction := ""
-	beg := 0
-	end := 0
-
-	for _, match := range matches {
-		end = match[0]
-		if direction != "" {
-			// write previous direction to output map
-			migrations[direction] = contents[beg:end]
-		}
-
-		// each match records the start of a new direction
-		direction = contents[match[2]:match[3]]
-		beg = match[1]
-	}
-
-	// write final direction to output map
-	migrations[direction] = contents[beg:]
-
-	return migrations, nil
-}
-
 // Rollback rolls back the most recent migration
 func (db *DB) Rollback() error {
 	drv, sqlDB, err := db.openDatabaseForMigration()
@@ -397,21 +368,29 @@ func (db *DB) Rollback() error {
 
 	fmt.Printf("Rolling back: %s\n", filename)
 
-	migration, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
+	_, down, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
 	if err != nil {
 		return err
 	}
 
-	// begin transaction
-	err = doTransaction(sqlDB, func(tx Transaction) error {
+	execMigration := func(tx Transaction) error {
 		// rollback migration
-		if _, err := tx.Exec(migration["down"]); err != nil {
+		if _, err := tx.Exec(down.Contents); err != nil {
 			return err
 		}
 
 		// remove migration record
 		return drv.DeleteMigration(tx, latest)
-	})
+	}
+
+	if down.Options.SkipTransaction() {
+		// run outside of transaction
+		err = execMigration(sqlDB)
+	} else {
+		// begin transaction
+		err = doTransaction(sqlDB, execMigration)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -268,12 +268,12 @@ func (db *DB) Migrate() error {
 			return drv.InsertMigration(tx, ver)
 		}
 
-		if up.Options.SkipTransaction() {
-			// run outside of transaction
-			err = execMigration(sqlDB)
-		} else {
+		if up.Options.Transaction() {
 			// begin transaction
 			err = doTransaction(sqlDB, execMigration)
+		} else {
+			// run outside of transaction
+			err = execMigration(sqlDB)
 		}
 
 		if err != nil {
@@ -383,12 +383,12 @@ func (db *DB) Rollback() error {
 		return drv.DeleteMigration(tx, latest)
 	}
 
-	if down.Options.SkipTransaction() {
-		// run outside of transaction
-		err = execMigration(sqlDB)
-	} else {
+	if down.Options.Transaction() {
 		// begin transaction
 		err = doTransaction(sqlDB, execMigration)
+	} else {
+		// run outside of transaction
+		err = execMigration(sqlDB)
 	}
 
 	if err != nil {

--- a/pkg/dbmate/migrations.go
+++ b/pkg/dbmate/migrations.go
@@ -1,0 +1,133 @@
+package dbmate
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+// MigrateOptions is an interface for accessing migration options
+type MigrateOptions interface {
+	SkipTransaction() bool
+}
+
+type migrateOptions map[string]string
+
+// SkipTransaction returns true if the migration is to run outside a transaction
+// Defaults to false.
+func (m migrateOptions) SkipTransaction() bool {
+	return m["skip_transaction"] == "true"
+}
+
+// NewMigrateOptions returns a MigrateOptions interface
+func NewMigrateOptions() MigrateOptions {
+	return make(migrateOptions)
+}
+
+// Migrate contains 'up' or 'down' migration commands and options
+type Migrate struct {
+	Direction string
+	Contents  string
+	Options   MigrateOptions
+}
+
+// NewMigrate constructs a Migrate object
+func NewMigrate(direction string) Migrate {
+	return Migrate{
+		Direction: direction,
+		Contents:  "",
+		Options:   make(migrateOptions),
+	}
+}
+
+// parseMigration reads a migration file and returns (up Migrate, down Migrate, error)
+func parseMigration(path string) (Migrate, Migrate, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return NewMigrate("up"), NewMigrate("down"), err
+	}
+	up, down := parseMigrationContents(string(data))
+	return up, down, nil
+}
+
+var reup = regexp.MustCompile(`(?m)^-- migrate:up\s+(.+)*$`)
+var redown = regexp.MustCompile(`(?m)^-- migrate:down\s+(.+)*$`)
+
+// parseMigrationContents parses the string contents of a migration.
+// It will return two Migrate objects, the first representing the "up"
+// block and the second representing the "down" block.
+//
+// Note that with the way this is currently defined, it is possible to
+// correctly parse a migration that does not define an "up" block or a
+// "down" block, or one that defines neither. This behavior is, in part,
+// to preserve backwards compatibility.
+func parseMigrationContents(contents string) (Migrate, Migrate) {
+	up := NewMigrate("up")
+	down := NewMigrate("down")
+
+	upMatch := reup.FindStringSubmatchIndex(contents)
+	downMatch := redown.FindStringSubmatchIndex(contents)
+
+	onlyDefinedUpBlock := len(upMatch) != 0 && len(downMatch) == 0
+	onlyDefinedDownBlock := len(upMatch) == 0 && len(downMatch) != 0
+
+	if onlyDefinedUpBlock {
+		up.Contents = strings.TrimSpace(contents)
+		up.Options = parseMigrateOptions(contents, upMatch[2], upMatch[3])
+	} else if onlyDefinedDownBlock {
+		down.Contents = strings.TrimSpace(contents)
+		down.Options = parseMigrateOptions(contents, downMatch[2], downMatch[3])
+	} else {
+		upStart := upMatch[0]
+		downStart := downMatch[0]
+
+		upEnd := downMatch[0]
+		downEnd := len(contents)
+
+		// If migrate:down was defined above migrate:up, correct the end indices
+		if upMatch[0] > downMatch[0] {
+			upEnd = downEnd
+			downEnd = upMatch[0]
+		}
+
+		up.Contents = strings.TrimSpace(contents[upStart:upEnd])
+		up.Options = parseMigrateOptions(contents, upMatch[2], upMatch[3])
+
+		down.Contents = strings.TrimSpace(contents[downStart:downEnd])
+		down.Options = parseMigrateOptions(contents, downMatch[2], downMatch[3])
+	}
+
+	return up, down
+}
+
+var whitespace = regexp.MustCompile(`\s+`)
+var optionSeparator = regexp.MustCompile(`:`)
+
+// parseMigrationOptions parses the options portion of a migration
+// block into an object that satisfies the MigrateOptions interface,
+// i.e., the 'transaction:false' piece of the following:
+//
+//     -- migrate:up transaction:false
+//     create table users (id serial, name string);
+//     -- migrate:down
+//     drop table users;
+//
+func parseMigrateOptions(contents string, begin, end int) MigrateOptions {
+	mOpts := make(migrateOptions)
+
+	if begin == -1 || end == -1 {
+		return mOpts
+	}
+
+	optionsString := strings.TrimSpace(contents[begin:end])
+
+	optionGroups := whitespace.Split(optionsString, -1)
+	for _, group := range optionGroups {
+		pair := optionSeparator.Split(group, -1)
+		if len(pair) == 2 {
+			mOpts[pair[0]] = pair[1]
+		}
+	}
+
+	return mOpts
+}

--- a/pkg/dbmate/migrations.go
+++ b/pkg/dbmate/migrations.go
@@ -8,15 +8,15 @@ import (
 
 // MigrationOptions is an interface for accessing migration options
 type MigrationOptions interface {
-	SkipTransaction() bool
+	Transaction() bool
 }
 
 type migrationOptions map[string]string
 
-// SkipTransaction returns true if the migration is to run outside a transaction
-// Defaults to false.
-func (m migrationOptions) SkipTransaction() bool {
-	return m["skip_transaction"] == "true"
+// Transaction returns whether or not this migration should run in a transaction
+// Defaults to true.
+func (m migrationOptions) Transaction() bool {
+	return m["transaction"] != "false"
 }
 
 // Migration contains the migration contents and options

--- a/pkg/dbmate/migrations.go
+++ b/pkg/dbmate/migrations.go
@@ -19,11 +19,6 @@ func (m migrateOptions) SkipTransaction() bool {
 	return m["skip_transaction"] == "true"
 }
 
-// NewMigrateOptions returns a MigrateOptions interface
-func NewMigrateOptions() MigrateOptions {
-	return make(migrateOptions)
-}
-
 // Migrate contains 'up' or 'down' migration commands and options
 type Migrate struct {
 	Direction string
@@ -50,8 +45,8 @@ func parseMigration(path string) (Migrate, Migrate, error) {
 	return up, down, nil
 }
 
-var reup = regexp.MustCompile(`(?m)^-- migrate:up\s+(.+)*$`)
-var redown = regexp.MustCompile(`(?m)^-- migrate:down\s+(.+)*$`)
+var upRegExp = regexp.MustCompile(`(?m)^-- migrate:up\s+(.+)*$`)
+var downRegExp = regexp.MustCompile(`(?m)^-- migrate:down\s+(.+)*$`)
 
 // parseMigrationContents parses the string contents of a migration.
 // It will return two Migrate objects, the first representing the "up"
@@ -65,8 +60,8 @@ func parseMigrationContents(contents string) (Migrate, Migrate) {
 	up := NewMigrate("up")
 	down := NewMigrate("down")
 
-	upMatch := reup.FindStringSubmatchIndex(contents)
-	downMatch := redown.FindStringSubmatchIndex(contents)
+	upMatch := upRegExp.FindStringSubmatchIndex(contents)
+	downMatch := downRegExp.FindStringSubmatchIndex(contents)
 
 	onlyDefinedUpBlock := len(upMatch) != 0 && len(downMatch) == 0
 	onlyDefinedDownBlock := len(upMatch) == 0 && len(downMatch) != 0
@@ -100,8 +95,8 @@ func parseMigrationContents(contents string) (Migrate, Migrate) {
 	return up, down
 }
 
-var whitespace = regexp.MustCompile(`\s+`)
-var optionSeparator = regexp.MustCompile(`:`)
+var whitespaceRegExp = regexp.MustCompile(`\s+`)
+var optionSeparatorRegExp = regexp.MustCompile(`:`)
 
 // parseMigrationOptions parses the options portion of a migration
 // block into an object that satisfies the MigrateOptions interface,
@@ -121,9 +116,9 @@ func parseMigrateOptions(contents string, begin, end int) MigrateOptions {
 
 	optionsString := strings.TrimSpace(contents[begin:end])
 
-	optionGroups := whitespace.Split(optionsString, -1)
+	optionGroups := whitespaceRegExp.Split(optionsString, -1)
 	for _, group := range optionGroups {
-		pair := optionSeparator.Split(group, -1)
+		pair := optionSeparatorRegExp.Split(group, -1)
 		if len(pair) == 2 {
 			mOpts[pair[0]] = pair[1]
 		}

--- a/pkg/dbmate/migrations_test.go
+++ b/pkg/dbmate/migrations_test.go
@@ -15,10 +15,10 @@ drop table users;`
 	up, down := parseMigrationContents(migration)
 
 	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
-	require.Equal(t, false, up.Options.SkipTransaction())
+	require.Equal(t, true, up.Options.Transaction())
 
 	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
-	require.Equal(t, false, down.Options.SkipTransaction())
+	require.Equal(t, true, down.Options.Transaction())
 
 	migration = `-- migrate:down
 drop table users;
@@ -29,22 +29,24 @@ create table users (id serial, name text);
 	up, down = parseMigrationContents(migration)
 
 	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
-	require.Equal(t, false, up.Options.SkipTransaction())
+	require.Equal(t, true, up.Options.Transaction())
 
 	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
-	require.Equal(t, false, down.Options.SkipTransaction())
+	require.Equal(t, true, down.Options.Transaction())
 
-	migration = `-- migrate:up skip_transaction:true
+	// This migration would not work in Postgres if it were to
+	// run in a transaction, so we would want to disable transactions.
+	migration = `-- migrate:up transaction:false
 ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 ALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';
 `
 
 	up, down = parseMigrationContents(migration)
 
-	require.Equal(t, "-- migrate:up skip_transaction:true\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\nALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';", up.Contents)
-	require.Equal(t, true, up.Options.SkipTransaction())
+	require.Equal(t, "-- migrate:up transaction:false\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\nALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';", up.Contents)
+	require.Equal(t, false, up.Options.Transaction())
 
 	require.Equal(t, "", down.Contents)
-	require.Equal(t, false, down.Options.SkipTransaction())
+	require.Equal(t, true, down.Options.Transaction())
 
 }

--- a/pkg/dbmate/migrations_test.go
+++ b/pkg/dbmate/migrations_test.go
@@ -1,0 +1,56 @@
+package dbmate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMigrationContents(t *testing.T) {
+	migration := `-- migrate:up
+create table users (id serial, name text);
+-- migrate:down
+drop table users;`
+
+	up, down := parseMigrationContents(migration)
+
+	require.Equal(t, "up", up.Direction)
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
+	require.Equal(t, false, up.Options.SkipTransaction())
+
+	require.Equal(t, "down", down.Direction)
+	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
+	require.Equal(t, false, down.Options.SkipTransaction())
+
+	migration = `-- migrate:down
+drop table users;
+-- migrate:up
+create table users (id serial, name text);
+`
+
+	up, down = parseMigrationContents(migration)
+
+	require.Equal(t, "up", up.Direction)
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
+	require.Equal(t, false, up.Options.SkipTransaction())
+
+	require.Equal(t, "down", down.Direction)
+	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
+	require.Equal(t, false, down.Options.SkipTransaction())
+
+	migration = `-- migrate:up skip_transaction:true
+ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
+ALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';
+`
+
+	up, down = parseMigrationContents(migration)
+
+	require.Equal(t, "up", up.Direction)
+	require.Equal(t, "-- migrate:up skip_transaction:true\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\nALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';", up.Contents)
+	require.Equal(t, true, up.Options.SkipTransaction())
+
+	require.Equal(t, "down", down.Direction)
+	require.Equal(t, "", down.Contents)
+	require.Equal(t, false, down.Options.SkipTransaction())
+
+}

--- a/pkg/dbmate/migrations_test.go
+++ b/pkg/dbmate/migrations_test.go
@@ -14,11 +14,9 @@ drop table users;`
 
 	up, down := parseMigrationContents(migration)
 
-	require.Equal(t, "up", up.Direction)
 	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
 	require.Equal(t, false, up.Options.SkipTransaction())
 
-	require.Equal(t, "down", down.Direction)
 	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
 	require.Equal(t, false, down.Options.SkipTransaction())
 
@@ -30,11 +28,9 @@ create table users (id serial, name text);
 
 	up, down = parseMigrationContents(migration)
 
-	require.Equal(t, "up", up.Direction)
 	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);", up.Contents)
 	require.Equal(t, false, up.Options.SkipTransaction())
 
-	require.Equal(t, "down", down.Direction)
 	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
 	require.Equal(t, false, down.Options.SkipTransaction())
 
@@ -45,11 +41,9 @@ ALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';
 
 	up, down = parseMigrationContents(migration)
 
-	require.Equal(t, "up", up.Direction)
 	require.Equal(t, "-- migrate:up skip_transaction:true\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\nALTER TYPE colors ADD VALUE 'yellow' AFTER 'orange';", up.Contents)
 	require.Equal(t, true, up.Options.SkipTransaction())
 
-	require.Equal(t, "down", down.Direction)
 	require.Equal(t, "", down.Contents)
 	require.Equal(t, false, down.Options.SkipTransaction())
 


### PR DESCRIPTION
Addresses #46 

This PR adds support for options. The only option implemented here is `transaction` which runs the the migration outside of a transaction when `false`. This is useful for certain statements which cannot run inside of a transaction, such as the `ALTER TYPE` statement used for adding values to enums in Postgres.

I took care to make sure this didn't break any existing functionality, but please point out if I missed something.

I'd love to end-to-end test this, but not every db in the test suite supports PG's enum syntax. I'm sure we could restructure some of the tests such that we end-to-end test this, but I only have so much time I can spend on this. For now, it's unit tested and should cover all the necessary cases.