### PR TITLE
Fix special chars passwords in MySQL Driver

### DIFF
--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -19,25 +19,25 @@ type MySQLDriver struct {
 }
 
 func normalizeMySQLURL(u *url.URL) string {
-	// set default port
-	host := u.Host
+	temporaryURL := *u // make a copy of u
 
-	if u.Port() == "" {
+	// set default port
+	host := temporaryURL.Host
+
+	if temporaryURL.Port() == "" {
 		host = fmt.Sprintf("%s:3306", host)
 	}
 
 	// host format required by go-sql-driver/mysql
 	host = fmt.Sprintf("tcp(%s)", host)
 
-	query := u.Query()
+	query := temporaryURL.Query()
 	query.Set("multiStatements", "true")
 
-	// I reutilized u, is this good practice?
-	// Should we make a copy of u and then work on it instead?
-	u.RawQuery = query.Encode()
+	temporaryURL.RawQuery = query.Encode()
 
 	// Get decoded user:pass
-	userPassEncoded := u.User.String()
+	userPassEncoded := temporaryURL.User.String()
 	userPass, _ := url.QueryUnescape(userPassEncoded)
 
 	// Build DSN w/ user:pass percent-decoded
@@ -48,7 +48,7 @@ func normalizeMySQLURL(u *url.URL) string {
 	}
 
 	normalizedString = fmt.Sprintf("%s%s%s", normalizedString,
-		host, u.RequestURI())
+		host, temporaryURL.RequestURI())
 
 	return normalizedString
 }

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -19,25 +19,23 @@ type MySQLDriver struct {
 }
 
 func normalizeMySQLURL(u *url.URL) string {
-	temporaryURL := *u // make a copy of u
-
 	// set default port
-	host := temporaryURL.Host
+	host := u.Host
 
-	if temporaryURL.Port() == "" {
+	if u.Port() == "" {
 		host = fmt.Sprintf("%s:3306", host)
 	}
 
 	// host format required by go-sql-driver/mysql
 	host = fmt.Sprintf("tcp(%s)", host)
 
-	query := temporaryURL.Query()
+	query := u.Query()
 	query.Set("multiStatements", "true")
 
-	temporaryURL.RawQuery = query.Encode()
+	queryString := query.Encode()
 
 	// Get decoded user:pass
-	userPassEncoded := temporaryURL.User.String()
+	userPassEncoded := u.User.String()
 	userPass, _ := url.QueryUnescape(userPassEncoded)
 
 	// Build DSN w/ user:pass percent-decoded
@@ -47,8 +45,8 @@ func normalizeMySQLURL(u *url.URL) string {
 		normalizedString = userPass + "@"
 	}
 
-	normalizedString = fmt.Sprintf("%s%s%s", normalizedString,
-		host, temporaryURL.RequestURI())
+	normalizedString = fmt.Sprintf("%s%s%s?%s", normalizedString,
+		host, u.Path, queryString)
 
 	return normalizedString
 }

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -35,7 +35,9 @@ func normalizeMySQLURL(u *url.URL) string {
 	normalizedURL.RawQuery = query.Encode()
 
 	str := normalizedURL.String()
-	return strings.TrimLeft(str, "/")
+	decodedValue, _ := url.QueryUnescape(str)
+
+	return strings.TrimLeft(decodedValue, "/")
 }
 
 // Open creates a new database connection

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -52,6 +52,15 @@ func TestNormalizeMySQLURLCustom(t *testing.T) {
 	require.Equal(t, "bob:secret@tcp(host:123)/foo?flag=on&multiStatements=true", s)
 }
 
+func TestNormalizeMySQLURLCustomSpecialChars(t *testing.T) {
+	u, err := url.Parse("mysql://duhfsd7s:123!@123!@@host:123/foo?flag=on")
+	require.NoError(t, err)
+	require.Equal(t, "123", u.Port())
+
+	s := normalizeMySQLURL(u)
+	require.Equal(t, "duhfsd7s:123!@123!@@tcp(host:123)/foo?flag=on&multiStatements=true", s)
+}
+
 func TestMySQLCreateDropDatabase(t *testing.T) {
 	drv := MySQLDriver{}
 	u := mySQLTestURL(t)


### PR DESCRIPTION
This PR aims to fix #57 
When MySQL password included special chars such as exclamation point or @ (at) MySQL backend errored out (invalid password).

https://github.com/amacneil/dbmate/blob/87c22515a9511c680e0391199cc3f53e0fc57eaf/pkg/dbmate/mysql.go#L21-L39

url.userinfo.String() (which gets called inside url.String()) returns %-encoded strings and MySQL interprets it as an actual password.
Now the function percent-decodes it first before returning.

This PR adds a test to cover special chars in MySQL.