### PR TITLE
Provide a reasonable error message to users

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func loadDotEnv() {
 	}
 
 	if err := godotenv.Load(); err != nil {
-		log.Fatal("Error loading .env file")
+		log.Fatalf("Error loading .env file: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
Currently, when the .env file cannot be parsed, the dbmate application
bombs with no explanation.  This commit prints out the error.