### PR TITLE
Cross-compile macOS and Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-DC := docker-compose
-BUILD_FLAGS := -ldflags '-s'
+LDFLAGS := -ldflags '-s'
 
 .PHONY: all
 all: test lint build
@@ -22,13 +21,27 @@ clean:
 	rm -rf dist
 
 .PHONY: build
-build: clean
-	GOARCH=amd64 go build $(BUILD_FLAGS) -o dist/dbmate-linux-amd64 .
-	# musl target does not support sqlite
-	GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o dist/dbmate-linux-musl-amd64 .
+build: clean build-linux build-macos build-windows
+	ls -lh dist
+
+.PHONY: build-linux
+build-linux:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
+	     go build $(LDFLAGS) -o dist/dbmate-linux-amd64 .
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+	     go build $(LDFLAGS) -o dist/dbmate-linux-musl-amd64 .
+
+.PHONY: build-macos
+build-macos:
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CC=o64-clang CXX=o64-clang++ \
+	     go build $(LDFLAGS) -o dist/dbmate-macos-amd64 .
+
+.PHONY: build-windows
+build-windows:
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix \
+	     go build $(LDFLAGS) -o dist/dbmate-windows-amd64.exe .
 
 .PHONY: docker
 docker:
-	$(DC) pull
-	$(DC) build
-	$(DC) run --rm dbmate make
+	docker-compose build
+	docker-compose run --rm dbmate make

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/amacneil/dbmate
 
+go 1.13
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.4.1

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -133,8 +133,10 @@ func TestMySQLDumpSchema(t *testing.T) {
 	u.Path = "/fakedb"
 	schema, err = drv.DumpSchema(u, db)
 	require.Nil(t, schema)
-	require.EqualError(t, err, "mysqldump: Got error: 1049: "+
-		"\"Unknown database 'fakedb'\" when selecting the database")
+	require.EqualError(t, err, "mysqldump: [Warning] Using a password "+
+		"on the command line interface can be insecure.\n"+
+		"mysqldump: Got error: 1049: "+
+		"Unknown database 'fakedb' when selecting the database")
 }
 
 func TestMySQLDatabaseExists(t *testing.T) {


### PR DESCRIPTION
Adds support for cross-compiling macOS and Windows builds with cgo (using https://github.com/techknowlogick/xgo).

Closes #41 