### PR TITLE
clarify that it simply uses SQL to define migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a comparison between dbmate and other popular database schema migration tool
 ## Features
 
 * Supports MySQL, PostgreSQL, and SQLite.
-* Powerful, [purpose-built DSL](https://en.wikipedia.org/wiki/SQL#Data_definition) for writing schema migrations.
+* Uses SQL for writing schema migrations.
 * Migrations are timestamp-versioned, to avoid version number conflicts with multiple developers.
 * Migrations are run atomically inside a transaction.
 * Supports creating and dropping databases (handy in development/test).


### PR DESCRIPTION
Not sure if my corrections is good, but as it is now it seems to suggest that there is a custom built DSL, while the DSL is just SQL, which I think everyone looking at a database migration tool is quite familiar with anyway.