### PR TITLE
Add status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ dbmate rollback  # roll back the most recent migration
 dbmate down      # alias for rollback
 dbmate dump      # write the database schema.sql file
 dbmate wait      # wait for the database server to become available
+dbmate status    # show the status of all migrations
 ```
 
 ## Usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,5 @@ services:
 
   postgres:
     image: postgres:9.6
+    environment:
+      POSTGRES_PASSWORD: postgres

--- a/main.go
+++ b/main.go
@@ -116,6 +116,13 @@ func NewApp() *cli.App {
 				return db.Wait()
 			}),
 		},
+		{
+			Name:  "status",
+			Usage: "Show the status of all migrations",
+			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				return db.Status()
+			}),
+		},
 	}
 
 	return app

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -35,6 +35,11 @@ type DB struct {
 	WaitTimeout    time.Duration
 }
 
+type statusResult struct {
+	filename string
+	applied  bool
+}
+
 // New initializes a new dbmate database
 func New(databaseURL *url.URL) *DB {
 	return &DB{
@@ -442,6 +447,71 @@ func (db *DB) Rollback() error {
 	if db.AutoDumpSchema {
 		_ = db.DumpSchema()
 	}
+
+	return nil
+}
+
+func checkMigrationsStatus(db *DB) ([]statusResult, error) {
+	re := regexp.MustCompile(`^\d.*\.sql$`)
+	files, err := findMigrationFiles(db.MigrationsDir, re)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no migration files found")
+	}
+
+	drv, sqlDB, err := db.openDatabaseForMigration()
+	if err != nil {
+		return nil, err
+	}
+	defer mustClose(sqlDB)
+
+	applied, err := drv.SelectMigrations(sqlDB, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []statusResult
+
+	for _, filename := range files {
+		ver := migrationVersion(filename)
+		res := statusResult{filename: filename}
+		if ok := applied[ver]; ok {
+			res.applied = true
+		} else {
+			res.applied = false
+		}
+
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+// Status show the status of all migrations
+func (db *DB) Status() error {
+	results, err := checkMigrationsStatus(db)
+	if err != nil {
+		return err
+	}
+
+	var totalApplied int
+
+	for _, res := range results {
+		if res.applied {
+			fmt.Println("[X]", res.filename)
+			totalApplied++
+		} else {
+			fmt.Println("[ ]", res.filename)
+		}
+	}
+
+	fmt.Println()
+
+	fmt.Printf("Up-to-date: %d\n", totalApplied)
+	fmt.Printf("Pending: %d\n", len(results)-totalApplied)
 
 	return nil
 }

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -305,9 +305,9 @@ func testRollbackURL(t *testing.T, u *url.URL) {
 	// verify rollback
 	err = sqlDB.QueryRow("select count(*) from schema_migrations").Scan(&count)
 	require.NoError(t, err)
-	require.Equal(t, 0, count)
+	require.Equal(t, 1, count)
 
-	err = sqlDB.QueryRow("select count(*) from users").Scan(&count)
+	err = sqlDB.QueryRow("select count(*) from foo").Scan(&count)
 	require.NotNil(t, err)
 	require.Regexp(t, "(does not exist|doesn't exist|no such table)", err.Error())
 }
@@ -315,5 +315,55 @@ func testRollbackURL(t *testing.T, u *url.URL) {
 func TestRollback(t *testing.T) {
 	for _, u := range testURLs(t) {
 		testRollbackURL(t, u)
+	}
+}
+
+func testStatusUrl(t *testing.T, u *url.URL) {
+	db := newTestDB(t, u)
+
+	// drop, recreate, and migrate database
+	err := db.Drop()
+	require.NoError(t, err)
+	err = db.Create()
+	require.NoError(t, err)
+
+	// verify migration
+	sqlDB, err := GetDriverOpen(u)
+	require.NoError(t, err)
+	defer mustClose(sqlDB)
+
+	// two pending
+	results, err := checkMigrationsStatus(db)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.False(t, results[0].applied)
+	require.False(t, results[1].applied)
+
+	// run migrations
+	err = db.Migrate()
+	require.NoError(t, err)
+
+	// two applied
+	results, err = checkMigrationsStatus(db)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.True(t, results[0].applied)
+	require.True(t, results[1].applied)
+
+	// rollback last migration
+	err = db.Rollback()
+	require.NoError(t, err)
+
+	// one applied, one pending
+	results, err = checkMigrationsStatus(db)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	require.True(t, results[0].applied)
+	require.False(t, results[1].applied)
+}
+
+func TestStatus(t *testing.T) {
+	for _, u := range testURLs(t) {
+		testStatusUrl(t, u)
 	}
 }

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -139,7 +139,7 @@ func TestPostgresDatabaseExists_Error(t *testing.T) {
 	u.User = url.User("invalid")
 
 	exists, err := drv.DatabaseExists(u)
-	require.Equal(t, "pq: role \"invalid\" does not exist", err.Error())
+	require.Equal(t, "pq: password authentication failed for user \"invalid\"", err.Error())
 	require.Equal(t, false, exists)
 }
 

--- a/testdata/db/migrations/20200227231541_test_status.sql
+++ b/testdata/db/migrations/20200227231541_test_status.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+create table foo (
+  id integer,
+  name varchar(255)
+);
+
+-- migrate:down
+drop table foo;


### PR DESCRIPTION
Hello!

I tried to finish the work for a status command started by @hmleal on PR #32.

It wasn't much easy to unit test it, since most of it is about the presentation. I managed to separate a bit the logic from the presentation and at least test the data extracted from the current migrated versions.

I also tried to implement the "summary only" as suggested by @MarkMurphy, but I could not quickly find a way to add a command specific flag, should be a quick in once it is figured out.