### PR TITLE
Add default docker postgres password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,5 @@ services:
 
   postgres:
     image: postgres:9.6
+    environment:
+      POSTGRES_PASSWORD: postgres

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -139,7 +139,7 @@ func TestPostgresDatabaseExists_Error(t *testing.T) {
 	u.User = url.User("invalid")
 
 	exists, err := drv.DatabaseExists(u)
-	require.Equal(t, "pq: role \"invalid\" does not exist", err.Error())
+	require.Equal(t, "pq: password authentication failed for user \"invalid\"", err.Error())
 	require.Equal(t, false, exists)
 }
 


### PR DESCRIPTION
Add a default user password to fix CI failures caused by [breaking upstream change](https://github.com/docker-library/postgres/pull/658) in `postgres` docker image.

Example error: https://travis-ci.org/amacneil/dbmate/builds/631760202