### PR TITLE
Add --exit-code and --quiet flags to status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ dbmate drop      # drop the database
 dbmate migrate   # run any pending migrations
 dbmate rollback  # roll back the most recent migration
 dbmate down      # alias for rollback
-dbmate status    # show the status of all migrations
+dbmate status    # show the status of all migrations (supports --exit-code and --quiet)
 dbmate dump      # write the database schema.sql file
 dbmate wait      # wait for the database server to become available
 ```

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -492,26 +492,33 @@ func checkMigrationsStatus(db *DB) ([]statusResult, error) {
 }
 
 // Status shows the status of all migrations
-func (db *DB) Status() error {
+func (db *DB) Status(quiet bool) (int, error) {
 	results, err := checkMigrationsStatus(db)
 	if err != nil {
-		return err
+		return -1, err
 	}
 
 	var totalApplied int
+	var line string
 
 	for _, res := range results {
 		if res.applied {
-			fmt.Println("[X]", res.filename)
+			line = fmt.Sprintf("[X] %s", res.filename)
 			totalApplied++
 		} else {
-			fmt.Println("[ ]", res.filename)
+			line = fmt.Sprintf("[ ] %s", res.filename)
+		}
+		if !quiet {
+			fmt.Println(line)
 		}
 	}
 
-	fmt.Println()
-	fmt.Printf("Applied: %d\n", totalApplied)
-	fmt.Printf("Pending: %d\n", len(results)-totalApplied)
+	totalPending := len(results) - totalApplied
+	if !quiet {
+		fmt.Println()
+		fmt.Printf("Applied: %d\n", totalApplied)
+		fmt.Printf("Pending: %d\n", totalPending)
+	}
 
-	return nil
+	return totalPending, nil
 }


### PR DESCRIPTION
Per suggestions from @MarkMurphy and @maximelebastard: extending the `dbmate status` command with the ability to set an exit code or quiet output, for use in scripts.

Flag names were copied from `git diff` command.

Also thanks to @fernandocarletti @hmleal @matguig for previous suggestions and PRs relating to this feature.