### PR TITLE
Exclusive migration locks

### DIFF
--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -17,6 +17,9 @@ type Driver interface {
 	SelectMigrations(*sql.DB, int) (map[string]bool, error)
 	InsertMigration(Transaction, string) error
 	DeleteMigration(Transaction, string) error
+	AcquireChangeLock(*sql.DB) (bool, error)
+	ReleaseChangeLock(*sql.DB) error
+	HasAChangeLock(*sql.DB) (bool, error)
 	Ping(*url.URL) error
 }
 

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -19,7 +19,6 @@ type Driver interface {
 	DeleteMigration(Transaction, string) error
 	AcquireChangeLock(*sql.DB) (bool, error)
 	ReleaseChangeLock(*sql.DB) error
-	HasAChangeLock(*sql.DB) (bool, error)
 	Ping(*url.URL) error
 }
 

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -17,8 +17,8 @@ type Driver interface {
 	SelectMigrations(*sql.DB, int) (map[string]bool, error)
 	InsertMigration(Transaction, string) error
 	DeleteMigration(Transaction, string) error
-	AcquireChangeLock(*sql.DB) (bool, error)
-	ReleaseChangeLock(*sql.DB) error
+	AcquireMigrationLock(*sql.DB) (bool, error)
+	ReleaseMigrationLock(*sql.DB) error
 	Ping(*url.URL) error
 }
 

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -244,7 +244,7 @@ func (drv MySQLDriver) DeleteMigration(db Transaction, version string) error {
 // reference counted and hence you must call `ReleaseChangeLock` the same number of times you call `AcquireChangeLock`
 func (drv MySQLDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
 	var result int8
-	err := db.QueryRow("select get_lock('dbmate', -1)").Scan(&result)
+	err := db.QueryRow("select get_lock('dbmate', 0)").Scan(&result)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -239,11 +239,11 @@ func (drv MySQLDriver) DeleteMigration(db Transaction, version string) error {
 	return err
 }
 
-// Acquires a change lock by setting an
+// Acquires a migration lock by setting an
 // [exclusive lock](https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock). NB! Locks are
-// reference counted and hence you must call `ReleaseChangeLock` the same number of times you call `AcquireChangeLock`
-// successfully
-func (drv MySQLDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
+// reference counted and hence you must call `ReleaseMigrationLock` the same number of times you call `AcquireMigrationLock`
+// successfully. All locks are released by MySQL on session/connection termination.
+func (drv MySQLDriver) AcquireMigrationLock(db *sql.DB) (bool, error) {
 	var result int8
 	err := db.QueryRow("select get_lock('dbmate', 0)").Scan(&result)
 	if err != nil {
@@ -253,8 +253,8 @@ func (drv MySQLDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
 	return result == 1, nil
 }
 
-// Releases a change lock acquired by `AcquireChangeLock`
-func (drv MySQLDriver) ReleaseChangeLock(db *sql.DB) error {
+// Releases a migration lock acquired by `AcquireMigrationLock`
+func (drv MySQLDriver) ReleaseMigrationLock(db *sql.DB) error {
 	result, err := db.Query("select release_lock('dbmate')")
 	if err != nil {
 		return err

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -262,17 +262,6 @@ func (drv MySQLDriver) ReleaseChangeLock(db *sql.DB) error {
 	return result.Close()
 }
 
-// Checks whether at least a change lock exists in any session (including this session)
-func (drv MySQLDriver) HasAChangeLock(db *sql.DB) (bool, error) {
-	var isUnusedLock bool
-	err := db.QueryRow("select is_used_lock('dbmate') is null").Scan(&isUnusedLock)
-	if err != nil {
-		return false, err
-	}
-
-	return !isUnusedLock, nil
-}
-
 // Ping verifies a connection to the database server. It does not verify whether the
 // specified database exists.
 func (drv MySQLDriver) Ping(u *url.URL) error {

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -242,6 +242,7 @@ func (drv MySQLDriver) DeleteMigration(db Transaction, version string) error {
 // Acquires a change lock by setting an
 // [exclusive lock](https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock). NB! Locks are
 // reference counted and hence you must call `ReleaseChangeLock` the same number of times you call `AcquireChangeLock`
+// successfully
 func (drv MySQLDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
 	var result int8
 	err := db.QueryRow("select get_lock('dbmate', 0)").Scan(&result)

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -265,12 +265,12 @@ func TestMySQLDeleteMigration(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
-func TestMySQLAcquireAndReleaseChangeLock(t *testing.T) {
+func TestMySQLAcquireAndReleaseMigrationLock(t *testing.T) {
 	drv := MySQLDriver{}
 	db := prepTestMySQLDB(t)
 	defer mustClose(db)
 
-	hasAChangeLock := func(db *sql.DB) (bool, error) {
+	hasALock := func(db *sql.DB) (bool, error) {
 		var isUnusedLock bool
 		err := db.QueryRow("select is_used_lock('dbmate') is null").Scan(&isUnusedLock)
 		if err != nil {
@@ -280,22 +280,22 @@ func TestMySQLAcquireAndReleaseChangeLock(t *testing.T) {
 		return !isUnusedLock, nil
 	}
 
-	hasLockBeforeAcquire, err := hasAChangeLock(db)
+	hasLockBeforeAcquire, err := hasALock(db)
 	require.NoError(t, err)
 	require.False(t, hasLockBeforeAcquire)
 
-	result1, err := drv.AcquireChangeLock(db)
+	result1, err := drv.AcquireMigrationLock(db)
 	require.NoError(t, err)
 	require.True(t, result1)
 
-	hasLock, err := hasAChangeLock(db)
+	hasLock, err := hasALock(db)
 	require.NoError(t, err)
 	require.True(t, hasLock)
 
-	err = drv.ReleaseChangeLock(db)
+	err = drv.ReleaseMigrationLock(db)
 	require.NoError(t, err)
 
-	hasLockAfterRelease, err := hasAChangeLock(db)
+	hasLockAfterRelease, err := hasALock(db)
 	require.NoError(t, err)
 	require.False(t, hasLockAfterRelease)
 }

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -265,6 +265,31 @@ func TestMySQLDeleteMigration(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+func TestMySQLAcquireAndReleaseChangeLock(t *testing.T) {
+	drv := MySQLDriver{}
+	db := prepTestMySQLDB(t)
+	defer mustClose(db)
+
+	hasLockBeforeAcquire, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.False(t, hasLockBeforeAcquire)
+
+	result1, err := drv.AcquireChangeLock(db)
+	require.NoError(t, err)
+	require.True(t, result1)
+
+	hasLock, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.True(t, hasLock)
+
+	err = drv.ReleaseChangeLock(db)
+	require.NoError(t, err)
+
+	hasLockAfterRelease, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.False(t, hasLockAfterRelease)
+}
+
 func TestMySQLPing(t *testing.T) {
 	drv := MySQLDriver{}
 	u := mySQLTestURL(t)

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -180,6 +180,7 @@ const advisoryLockKey = 621
 // Acquires a change lock by setting a
 // [pg advisory lock](https://www.postgresql.org/docs/9.4/explicit-locking.html#ADVISORY-LOCKS). NB! Locks are
 // reference counted and hence you must call `ReleaseChangeLock` the same number of times you call `AcquireChangeLock`
+// successfully
 func (drv PostgresDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
 	var result string
 	err := db.QueryRow(fmt.Sprintf("select pg_try_advisory_lock(%d)", advisoryLockKey)).Scan(&result)

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -177,11 +177,11 @@ func (drv PostgresDriver) DeleteMigration(db Transaction, version string) error 
 // The sum of all charCodes in the string "dbmate" :)
 const advisoryLockKey = 621
 
-// Acquires a change lock by setting a
+// Acquires a migration lock by setting a
 // [pg advisory lock](https://www.postgresql.org/docs/9.4/explicit-locking.html#ADVISORY-LOCKS). NB! Locks are
-// reference counted and hence you must call `ReleaseChangeLock` the same number of times you call `AcquireChangeLock`
-// successfully
-func (drv PostgresDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
+// reference counted and hence you must call `ReleaseMigrationLock` the same number of times you call `AcquireMigrationLock`
+// successfully. All locks are released by Postgres on session/connection termination.
+func (drv PostgresDriver) AcquireMigrationLock(db *sql.DB) (bool, error) {
 	var result string
 	err := db.QueryRow(fmt.Sprintf("select pg_try_advisory_lock(%d)", advisoryLockKey)).Scan(&result)
 	if err != nil {
@@ -191,8 +191,8 @@ func (drv PostgresDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
 	return result == "true", nil
 }
 
-// Releases a change lock acquired by `AcquireChangeLock`
-func (drv PostgresDriver) ReleaseChangeLock(db *sql.DB) error {
+// Releases a migration lock acquired by `AcquireMigrationLock`
+func (drv PostgresDriver) ReleaseMigrationLock(db *sql.DB) error {
 	res, err := db.Query(fmt.Sprintf("select pg_advisory_unlock(%d)", advisoryLockKey))
 	if err != nil {
 		return err

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -201,17 +201,6 @@ func (drv PostgresDriver) ReleaseChangeLock(db *sql.DB) error {
 	return err
 }
 
-// Checks whether at least a change lock exists in any session (including this session)
-func (drv PostgresDriver) HasAChangeLock(db *sql.DB) (bool, error) {
-	var locksCount int
-	err := db.QueryRow(fmt.Sprintf("select count(*) from pg_locks where objid = %d and locktype = 'advisory'", advisoryLockKey)).Scan(&locksCount)
-	if err != nil {
-		return false, err
-	}
-
-	return locksCount > 0, nil
-}
-
 // Ping verifies a connection to the database server. It does not verify whether the
 // specified database exists.
 func (drv PostgresDriver) Ping(u *url.URL) error {

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -236,6 +236,31 @@ func TestPostgresDeleteMigration(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+func TestPostgresAcquireAndReleaseChangeLock(t *testing.T) {
+	drv := PostgresDriver{}
+	db := prepTestPostgresDB(t)
+	defer mustClose(db)
+
+	hasLockBeforeAcquire, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.False(t, hasLockBeforeAcquire)
+
+	result1, err := drv.AcquireChangeLock(db)
+	require.NoError(t, err)
+	require.True(t, result1)
+
+	hasLock, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.True(t, hasLock)
+
+	err = drv.ReleaseChangeLock(db)
+	require.NoError(t, err)
+
+	hasLockAfterRelease, err := drv.HasAChangeLock(db)
+	require.NoError(t, err)
+	require.False(t, hasLockAfterRelease)
+}
+
 func TestPostgresPing(t *testing.T) {
 	drv := PostgresDriver{}
 	u := postgresTestURL(t)

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -166,14 +166,14 @@ func (drv SQLiteDriver) DeleteMigration(db Transaction, version string) error {
 }
 
 // Does nothing currently
-func (drv SQLiteDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
-	// FIXME use change locking for this driver also?
+func (drv SQLiteDriver) AcquireMigrationLock(db *sql.DB) (bool, error) {
+	// FIXME use migration locking for this driver also?
 	fmt.Println("Skipping migration locking because database driver is SQLite")
 	return true, nil
 }
 
-func (drv SQLiteDriver) ReleaseChangeLock(db *sql.DB) error {
-	// FIXME use change locking for this driver also?
+func (drv SQLiteDriver) ReleaseMigrationLock(db *sql.DB) error {
+	// FIXME use migration locking for this driver also?
 	return nil
 }
 

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -181,34 +181,6 @@ func (drv SQLiteDriver) HasAChangeLock(db *sql.DB) (bool, error) {
 	return false, nil
 }
 
-//// Creates the schema_migrations_change_lock table
-//func (drv SQLiteDriver) CreateMigrationsChangeLockTable(db *sql.DB) error {
-//	_, err := db.Exec("create table if not exists schema_migrations_change_lock " +
-//		"(hostname varchar(255) primary key, locked_at timestamp)")
-//
-//	return err
-//}
-//
-//// Selects the hostname of any acquired change lock, or empty if not locked
-//func (drv SQLiteDriver) SelectAcquiredChangeLock(db *sql.DB) (string, error) {
-//	const query = "select hostname from schema_migrations_change_lock limit 1"
-//
-//	var hostname string
-//	rows, err := db.Query(query)
-//	if err != nil {
-//		return "", err
-//	}
-//	defer mustClose(rows)
-//	if rows.Next() {
-//		err = rows.Scan(&hostname)
-//		if err != nil {
-//			return "", err
-//		}
-//	}
-//
-//	return hostname, nil
-//}
-
 // Ping verifies a connection to the database. Due to the way SQLite works, by
 // testing whether the database is valid, it will automatically create the database
 // if it does not already exist.

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -165,6 +165,50 @@ func (drv SQLiteDriver) DeleteMigration(db Transaction, version string) error {
 	return err
 }
 
+// Does nothing currently
+func (drv SQLiteDriver) AcquireChangeLock(db *sql.DB) (bool, error) {
+	// FIXME use change locking for this driver also?
+	fmt.Println("Skipping migration locking because database driver is SQLite")
+	return true, nil
+}
+
+func (drv SQLiteDriver) ReleaseChangeLock(db *sql.DB) error {
+	// FIXME use change locking for this driver also?
+	return nil
+}
+
+func (drv SQLiteDriver) HasAChangeLock(db *sql.DB) (bool, error) {
+	return false, nil
+}
+
+//// Creates the schema_migrations_change_lock table
+//func (drv SQLiteDriver) CreateMigrationsChangeLockTable(db *sql.DB) error {
+//	_, err := db.Exec("create table if not exists schema_migrations_change_lock " +
+//		"(hostname varchar(255) primary key, locked_at timestamp)")
+//
+//	return err
+//}
+//
+//// Selects the hostname of any acquired change lock, or empty if not locked
+//func (drv SQLiteDriver) SelectAcquiredChangeLock(db *sql.DB) (string, error) {
+//	const query = "select hostname from schema_migrations_change_lock limit 1"
+//
+//	var hostname string
+//	rows, err := db.Query(query)
+//	if err != nil {
+//		return "", err
+//	}
+//	defer mustClose(rows)
+//	if rows.Next() {
+//		err = rows.Scan(&hostname)
+//		if err != nil {
+//			return "", err
+//		}
+//	}
+//
+//	return hostname, nil
+//}
+
 // Ping verifies a connection to the database. Due to the way SQLite works, by
 // testing whether the database is valid, it will automatically create the database
 // if it does not already exist.

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -177,10 +177,6 @@ func (drv SQLiteDriver) ReleaseChangeLock(db *sql.DB) error {
 	return nil
 }
 
-func (drv SQLiteDriver) HasAChangeLock(db *sql.DB) (bool, error) {
-	return false, nil
-}
-
 // Ping verifies a connection to the database. Due to the way SQLite works, by
 // testing whether the database is valid, it will automatically create the database
 // if it does not already exist.

--- a/pkg/dbmate/sqlite_test.go
+++ b/pkg/dbmate/sqlite_test.go
@@ -213,51 +213,6 @@ func TestSQLiteDeleteMigration(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
-//func TestSQLiteCreateMigrationsChangeLockTable(t *testing.T) {
-//	drv := SQLiteDriver{}
-//	db := prepTestSQLiteDB(t)
-//	defer mustClose(db)
-//
-//	// migrations change lock table should not exist
-//	count := 0
-//	err := db.QueryRow("select count(*) from schema_migrations_change_lock").Scan(&count)
-//	require.Regexp(t, "no such table: schema_migrations_change_lock", err.Error())
-//
-//	// create table
-//	err = drv.CreateMigrationsChangeLockTable(db)
-//	require.NoError(t, err)
-//
-//	// migrations change lock table should exist
-//	err = db.QueryRow("select count(*) from schema_migrations_change_lock").Scan(&count)
-//	require.NoError(t, err)
-//
-//	// create table should be idempotent
-//	err = drv.CreateMigrationsChangeLockTable(db)
-//	require.NoError(t, err)
-//}
-//
-//func TestSQLiteSelectAcquiredChangeLock(t *testing.T) {
-//	drv := SQLiteDriver{}
-//	db := prepTestSQLiteDB(t)
-//	defer mustClose(db)
-//
-//	err := drv.CreateMigrationsChangeLockTable(db)
-//	require.NoError(t, err)
-//
-//	// no lock
-//	lock, err := drv.SelectAcquiredChangeLock(db)
-//	require.NoError(t, err)
-//	require.Empty(t, lock)
-//
-//	// with lock
-//	_, err = db.Exec("insert into schema_migrations_change_lock (hostname, locked_at) " +
-//		"values ('my-super-server', current_timestamp)")
-//	require.NoError(t, err)
-//	lock, err = drv.SelectAcquiredChangeLock(db)
-//	require.NoError(t, err)
-//	require.Equal(t, "my-super-server", lock)
-//}
-
 func TestSQLitePing(t *testing.T) {
 	drv := SQLiteDriver{}
 	u := sqliteTestURL(t)

--- a/pkg/dbmate/sqlite_test.go
+++ b/pkg/dbmate/sqlite_test.go
@@ -213,6 +213,51 @@ func TestSQLiteDeleteMigration(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+//func TestSQLiteCreateMigrationsChangeLockTable(t *testing.T) {
+//	drv := SQLiteDriver{}
+//	db := prepTestSQLiteDB(t)
+//	defer mustClose(db)
+//
+//	// migrations change lock table should not exist
+//	count := 0
+//	err := db.QueryRow("select count(*) from schema_migrations_change_lock").Scan(&count)
+//	require.Regexp(t, "no such table: schema_migrations_change_lock", err.Error())
+//
+//	// create table
+//	err = drv.CreateMigrationsChangeLockTable(db)
+//	require.NoError(t, err)
+//
+//	// migrations change lock table should exist
+//	err = db.QueryRow("select count(*) from schema_migrations_change_lock").Scan(&count)
+//	require.NoError(t, err)
+//
+//	// create table should be idempotent
+//	err = drv.CreateMigrationsChangeLockTable(db)
+//	require.NoError(t, err)
+//}
+//
+//func TestSQLiteSelectAcquiredChangeLock(t *testing.T) {
+//	drv := SQLiteDriver{}
+//	db := prepTestSQLiteDB(t)
+//	defer mustClose(db)
+//
+//	err := drv.CreateMigrationsChangeLockTable(db)
+//	require.NoError(t, err)
+//
+//	// no lock
+//	lock, err := drv.SelectAcquiredChangeLock(db)
+//	require.NoError(t, err)
+//	require.Empty(t, lock)
+//
+//	// with lock
+//	_, err = db.Exec("insert into schema_migrations_change_lock (hostname, locked_at) " +
+//		"values ('my-super-server', current_timestamp)")
+//	require.NoError(t, err)
+//	lock, err = drv.SelectAcquiredChangeLock(db)
+//	require.NoError(t, err)
+//	require.Equal(t, "my-super-server", lock)
+//}
+
 func TestSQLitePing(t *testing.T) {
 	drv := SQLiteDriver{}
 	u := sqliteTestURL(t)


### PR DESCRIPTION
A first take on addressing https://github.com/amacneil/dbmate/issues/101

I have a couple of minor issues idk how to tackle, so would be amaze with some feedback :)

One small thing: Do you think we should have a timeout on the change lock (in case of deadlocks) or nah? I think not having it would be better, considering some migrations could take a lot of time and the risk for deadocks is quite low considering the locking expires on session termination.

The main thing: Idk exactly what to do about SQLite, shall we skip it or implement our own locking mechanism? Skipping _could_ be OK for SQLite in particular I guess, because I don't really see a use case where you run concurrent migration scripts against a single database file. That being said, it would also feel bad to skip one particular driver, but due to SQLite not having any locking mechanism for a full open session (that I can find, that is) it becomes slightly more complicated than for the other drivers. Totally solvable though, so just let me know your thoughts and I'll make some final fixes accordingly!