### PR TITLE
Add MySQL connection through socket file

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ protocol://username:password@host:port/database_name?options
 DATABASE_URL="mysql://username:password@127.0.0.1:3306/database_name"
 ```
 
+A socket parameter can be specified to connect through an unix socket file:
+
+```sh
+DATABASE_URL="mysql://username:password@localhost/database_name?socket=/var/data/mysql.sock"
+```
+
 **PostgreSQL**
 
 When connecting to Postgres, you may need to add the `sslmode=disable` option to your connection string, as dbmate by default requires a TLS connection (some other frameworks/languages allow unencrypted connections by default).

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ protocol://username:password@host:port/database_name?options
 DATABASE_URL="mysql://username:password@127.0.0.1:3306/database_name"
 ```
 
-A socket parameter can be specified to connect through an unix socket file:
+A socket parameter can be specified to connect through a unix socket file:
 
 ```sh
 DATABASE_URL="mysql://username:password@localhost/database_name?socket=/var/data/mysql.sock"

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -34,6 +34,7 @@ func normalizeMySQLURL(u *url.URL) string {
 	host = fmt.Sprintf("%s(%s)", protocol, host)
 
 	query := u.Query()
+	query.Del("socket")
 	query.Set("multiStatements", "true")
 
 	queryString := query.Encode()

--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -21,13 +21,17 @@ type MySQLDriver struct {
 func normalizeMySQLURL(u *url.URL) string {
 	// set default port
 	host := u.Host
+	protocol := "tcp"
 
-	if u.Port() == "" {
+	if u.Query().Get("socket") != "" {
+		protocol = "unix"
+		host = u.Query().Get("socket")
+	} else if u.Port() == "" {
 		host = fmt.Sprintf("%s:3306", host)
 	}
 
 	// host format required by go-sql-driver/mysql
-	host = fmt.Sprintf("tcp(%s)", host)
+	host = fmt.Sprintf("%s(%s)", protocol, host)
 
 	query := u.Query()
 	query.Set("multiStatements", "true")


### PR DESCRIPTION
For MySQL connections, if a `socket` parameter is specified in query URL the connection to the database goes through the unix socket file specified