### PR TITLE
Add postgres support for socket parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ protocol://username:password@host:port/database_name?options
 DATABASE_URL="mysql://username:password@127.0.0.1:3306/database_name"
 ```
 
-A socket parameter can be specified to connect through a unix socket file:
+A `socket` parameter can be specified to connect through a unix socket:
 
 ```sh
 DATABASE_URL="mysql://username:password@/database_name?socket=/var/run/mysqld/mysqld.sock"
@@ -139,6 +139,12 @@ When connecting to Postgres, you may need to add the `sslmode=disable` option to
 
 ```sh
 DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?sslmode=disable"
+```
+
+A `socket` or `host` parameter can be specified to connect through a unix socket (note: specify the directory only):
+
+```sh
+DATABASE_URL="postgres://username:password@/database_name?socket=/var/run/postgresql"
 ```
 
 **SQLite**

--- a/pkg/dbmate/mysql_test.go
+++ b/pkg/dbmate/mysql_test.go
@@ -62,12 +62,20 @@ func TestNormalizeMySQLURLCustomSpecialChars(t *testing.T) {
 }
 
 func TestNormalizeMySQLURLSocket(t *testing.T) {
+	// test with no user/pass
 	u, err := url.Parse("mysql:///foo?socket=/var/run/mysqld/mysqld.sock&flag=on")
 	require.NoError(t, err)
 	require.Equal(t, "", u.Host)
 
 	s := normalizeMySQLURL(u)
 	require.Equal(t, "unix(/var/run/mysqld/mysqld.sock)/foo?flag=on&multiStatements=true", s)
+
+	// test with user/pass
+	u, err = url.Parse("mysql://bob:secret@fakehost/foo?socket=/var/run/mysqld/mysqld.sock&flag=on")
+	require.NoError(t, err)
+
+	s = normalizeMySQLURL(u)
+	require.Equal(t, "bob:secret@unix(/var/run/mysqld/mysqld.sock)/foo?flag=on&multiStatements=true", s)
 }
 
 func TestMySQLCreateDropDatabase(t *testing.T) {


### PR DESCRIPTION
Simplifies connecting to postgres via sockets (https://github.com/amacneil/dbmate/issues/107), and standardize the `socket` parameter across both mysql and postgresql.