### PR TITLE
Add sql clients to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ ENTRYPOINT []
 CMD ["/bin/bash"]
 
 # runtime image
-FROM scratch
-COPY --from=build /src/dist/dbmate-linux-amd64 /dbmate
-ENTRYPOINT ["/dbmate"]
+FROM alpine
+RUN apk add --no-cache \
+        mariadb-client \
+        postgresql-client \
+        sqlite
+COPY --from=build /src/dist/dbmate-linux-amd64 /usr/local/bin/dbmate
+ENTRYPOINT ["dbmate"]


### PR DESCRIPTION
Instead of a nice super-minimal production docker image, create one based on alpine with sql clients installed (`mariadb-client`, `postgresql-client`, and `sqlite`).

* Increases docker image size from 10 MB to 56 MB 👎 
* Allows people to run `dbmate dump` command with our docker image (fixes #114) 👍 
* I'm not sure what compatibility is like between `mysqldump` from `mariadb-client` versus `mysql-client`, but starting here since mariadb is included with alpine, and the version I built using mysql and ubuntu weighed in at 165 MB. 🤔 