### PR TITLE
postgres: Support custom schema for schema_migrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,15 @@ A `socket` or `host` parameter can be specified to connect through a unix socket
 DATABASE_URL="postgres://username:password@/database_name?socket=/var/run/postgresql"
 ```
 
-A `schema` or `search_path` parameter can be specified, which will be used as the current schema while applying migrations,
-as well as the schema for dbmate's `schema_migrations` table.
+A `search_path` parameter can be used to specify the [current schema](https://www.postgresql.org/docs/13/ddl-schemas.html#DDL-SCHEMAS-PATH) while applying migrations, as well as for dbmate's `schema_migrations` table.
+If multiple comma-separated schemas are passed, the first will be used for the `schema_migrations` table.
 
 ```sh
-DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?schema=myschema"
+DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?search_path=myschema"
+```
+
+```sh
+DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?search_path=myschema,public"
 ```
 
 **SQLite**

--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ A `socket` or `host` parameter can be specified to connect through a unix socket
 DATABASE_URL="postgres://username:password@/database_name?socket=/var/run/postgresql"
 ```
 
+A `schema` or `search_path` parameter can be specified, which will be used as the current schema while applying migrations,
+as well as the schema for dbmate's `schema_migrations` table.
+
+```sh
+DATABASE_URL="postgres://username:password@127.0.0.1:5432/database_name?schema=myschema"
+```
+
 **SQLite**
 
 SQLite databases are stored on the filesystem, so you do not need to specify a host. By default, files are relative to the current directory. For example, the following will create a database at `./db/database_name.sqlite3`:

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -30,6 +30,8 @@ func RegisterDriver(drv Driver, scheme string) {
 // Transaction can represent a database or open transaction
 type Transaction interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
 // GetDriver loads a database driver by name

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -30,12 +30,6 @@ func normalizePostgresURL(u *url.URL) *url.URL {
 		query.Del("socket")
 	}
 
-	// support schema parameter
-	if query.Get("schema") != "" {
-		query.Set("search_path", query.Get("schema"))
-		query.Del("schema")
-	}
-
 	// default hostname
 	if hostname == "" {
 		hostname = "localhost"
@@ -298,6 +292,7 @@ func (drv PostgresDriver) migrationsTableName(db Transaction) (string, error) {
 		return "", err
 	}
 
+	// if the search path is empty, or does not contain a valid schema, default to public
 	if schema == "" {
 		schema = "public"
 	}

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -30,6 +30,12 @@ func normalizePostgresURL(u *url.URL) *url.URL {
 		query.Del("socket")
 	}
 
+	// support schema parameter
+	if query.Get("schema") != "" {
+		query.Set("search_path", query.Get("schema"))
+		query.Del("schema")
+	}
+
 	// default hostname
 	if hostname == "" {
 		hostname = "localhost"

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -45,8 +45,6 @@ func TestNormalizePostgresURL(t *testing.T) {
 		// support `host` and `port` via url params
 		{"postgres://bob:secret@myhost:1234/foo?host=new&port=9999", "postgres://bob:secret@:9999/foo?host=new"},
 		{"postgres://bob:secret@myhost:1234/foo?port=9999&bar=baz", "postgres://bob:secret@myhost:9999/foo?bar=baz"},
-		// support schema param
-		{"postgres://myhost:1234/foo?schema=foo", "postgres://myhost:1234/foo?search_path=foo"},
 		// support unix sockets via `host` or `socket` param
 		{"postgres://bob:secret@myhost:1234/foo?host=/var/run/postgresql", "postgres://bob:secret@:1234/foo?host=%2Fvar%2Frun%2Fpostgresql"},
 		{"postgres://bob:secret@localhost/foo?socket=/var/run/postgresql", "postgres://bob:secret@:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"},
@@ -331,12 +329,11 @@ func TestMigrationsTableName(t *testing.T) {
 		require.NoError(t, err)
 		db := prepTestPostgresDB(t, u)
 		defer mustClose(db)
-		defer func() {
-			_, _ = db.Exec("drop schema if exists foo")
-		}()
 
 		// if "foo" schema does not exist, current schema should be "public"
 		_, err = db.Exec("drop schema if exists foo")
+		require.NoError(t, err)
+		_, err = db.Exec("drop schema if exists bar")
 		require.NoError(t, err)
 		name, err := drv.migrationsTableName(db)
 		require.NoError(t, err)

--- a/pkg/dbmate/postgres_test.go
+++ b/pkg/dbmate/postgres_test.go
@@ -45,6 +45,8 @@ func TestNormalizePostgresURL(t *testing.T) {
 		// support `host` and `port` via url params
 		{"postgres://bob:secret@myhost:1234/foo?host=new&port=9999", "postgres://bob:secret@:9999/foo?host=new"},
 		{"postgres://bob:secret@myhost:1234/foo?port=9999&bar=baz", "postgres://bob:secret@myhost:9999/foo?bar=baz"},
+		// support schema param
+		{"postgres://myhost:1234/foo?schema=foo", "postgres://myhost:1234/foo?search_path=foo"},
 		// support unix sockets via `host` or `socket` param
 		{"postgres://bob:secret@myhost:1234/foo?host=/var/run/postgresql", "postgres://bob:secret@:1234/foo?host=%2Fvar%2Frun%2Fpostgresql"},
 		{"postgres://bob:secret@localhost/foo?socket=/var/run/postgresql", "postgres://bob:secret@:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"},

--- a/pkg/dbmate/utils.go
+++ b/pkg/dbmate/utils.go
@@ -104,7 +104,7 @@ func trimLeadingSQLComments(data []byte) ([]byte, error) {
 // queryColumn runs a SQL statement and returns a slice of strings
 // it is assumed that the statement returns only one column
 // e.g. schema_migrations table
-func queryColumn(db *sql.DB, query string) ([]string, error) {
+func queryColumn(db Transaction, query string) ([]string, error) {
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, err
@@ -126,6 +126,19 @@ func queryColumn(db *sql.DB, query string) ([]string, error) {
 	}
 
 	return result, nil
+}
+
+// queryRow runs a SQL statement and returns a single string
+// it is assumed that the statement returns only one row and one column
+// sql NULL is returned as empty string
+func queryRow(db Transaction, query string) (string, error) {
+	var result sql.NullString
+	err := db.QueryRow(query).Scan(&result)
+	if err != nil || !result.Valid {
+		return "", err
+	}
+
+	return result.String, nil
 }
 
 func printVerbose(result sql.Result) {


### PR DESCRIPTION
Instead of hardcoding `schema_migrations` table to the `public` schema, add support for specifying a schema via the `search_path` URL parameter.

**Backwards compatibility note**: If anyone was using the previously undocumented `search_path` behavior (affecting migrations themselves, but always storing the `schema_migrations` table in `public`), you will need to either prepend `public` to your `search_path`, or migrate your `schema_migrations` table to your primary schema:

```sql
ALTER TABLE public.schema_migrations SET SCHEMA myschema;
```

cc @RabidFire

Closes #110 