### PR TITLE
Create the schema_migrations table using latin1 charset in MySQL

### DIFF
--- a/pkg/dbmate/mysql.go
+++ b/pkg/dbmate/mysql.go
@@ -194,7 +194,7 @@ func (drv MySQLDriver) DatabaseExists(u *url.URL) (bool, error) {
 // CreateMigrationsTable creates the schema_migrations table
 func (drv MySQLDriver) CreateMigrationsTable(u *url.URL, db *sql.DB) error {
 	_, err := db.Exec("create table if not exists schema_migrations " +
-		"(version varchar(255) primary key)")
+		"(version varchar(255) primary key) character set latin1 collate latin1_bin")
 
 	return err
 }


### PR DESCRIPTION
This pull request force the `schema_migrations` table to be created with `latin1` character set, to fix the behavior of `dbmate` in MariaDB 10.1 and older (or MySQL 5.5 and older) when the system charset has more than 1 byte per character (e.g. utf8mb4) - see #85 