### PR TITLE
Ability to specify custom migrations table name

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ func NewApp() *cli.App {
 			Usage:   "specify the directory containing migration files",
 		},
 		&cli.StringFlag{
+			Name:    "migrations-table",
+			EnvVars: []string{"DBMATE_MIGRATIONS_TABLE"},
+			Value:   dbmate.DefaultMigrationsTableName,
+			Usage:   "specify the database table to record migrations in",
+		},
+		&cli.StringFlag{
 			Name:    "schema-file",
 			Aliases: []string{"s"},
 			EnvVars: []string{"DBMATE_SCHEMA_FILE"},
@@ -222,6 +228,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		db := dbmate.New(u)
 		db.AutoDumpSchema = !c.Bool("no-dump-schema")
 		db.MigrationsDir = c.String("migrations-dir")
+		db.MigrationsTableName = c.String("migrations-table")
 		db.SchemaFile = c.String("schema-file")
 		db.WaitBefore = c.Bool("wait")
 		overrideTimeout := c.Duration("wait-timeout")

--- a/pkg/dbmate/driver_test.go
+++ b/pkg/dbmate/driver_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestGetDriver_Postgres(t *testing.T) {
-	drv, err := GetDriver("postgres")
+	drv, err := getDriver("postgres")
 	require.NoError(t, err)
-	_, ok := drv.(PostgresDriver)
+	_, ok := drv.(*PostgresDriver)
 	require.Equal(t, true, ok)
 }
 
 func TestGetDriver_MySQL(t *testing.T) {
-	drv, err := GetDriver("mysql")
+	drv, err := getDriver("mysql")
 	require.NoError(t, err)
-	_, ok := drv.(MySQLDriver)
+	_, ok := drv.(*MySQLDriver)
 	require.Equal(t, true, ok)
 }
 
 func TestGetDriver_Error(t *testing.T) {
-	drv, err := GetDriver("foo")
+	drv, err := getDriver("foo")
 	require.EqualError(t, err, "unsupported driver: foo")
 	require.Nil(t, drv)
 }

--- a/pkg/dbmate/postgres.go
+++ b/pkg/dbmate/postgres.go
@@ -11,12 +11,14 @@ import (
 )
 
 func init() {
-	RegisterDriver(PostgresDriver{}, "postgres")
-	RegisterDriver(PostgresDriver{}, "postgresql")
+	drv := &PostgresDriver{}
+	RegisterDriver(drv, "postgres")
+	RegisterDriver(drv, "postgresql")
 }
 
 // PostgresDriver provides top level database functions
 type PostgresDriver struct {
+	migrationsTableName string
 }
 
 func normalizePostgresURL(u *url.URL) *url.URL {
@@ -78,12 +80,17 @@ func normalizePostgresURLForDump(u *url.URL) []string {
 	return out
 }
 
+// SetMigrationsTableName sets the schema migrations table name
+func (drv *PostgresDriver) SetMigrationsTableName(name string) {
+	drv.migrationsTableName = name
+}
+
 // Open creates a new database connection
-func (drv PostgresDriver) Open(u *url.URL) (*sql.DB, error) {
+func (drv *PostgresDriver) Open(u *url.URL) (*sql.DB, error) {
 	return sql.Open("postgres", normalizePostgresURL(u).String())
 }
 
-func (drv PostgresDriver) openPostgresDB(u *url.URL) (*sql.DB, error) {
+func (drv *PostgresDriver) openPostgresDB(u *url.URL) (*sql.DB, error) {
 	// connect to postgres database
 	postgresURL := *u
 	postgresURL.Path = "postgres"
@@ -92,7 +99,7 @@ func (drv PostgresDriver) openPostgresDB(u *url.URL) (*sql.DB, error) {
 }
 
 // CreateDatabase creates the specified database
-func (drv PostgresDriver) CreateDatabase(u *url.URL) error {
+func (drv *PostgresDriver) CreateDatabase(u *url.URL) error {
 	name := databaseName(u)
 	fmt.Printf("Creating: %s\n", name)
 
@@ -109,7 +116,7 @@ func (drv PostgresDriver) CreateDatabase(u *url.URL) error {
 }
 
 // DropDatabase drops the specified database (if it exists)
-func (drv PostgresDriver) DropDatabase(u *url.URL) error {
+func (drv *PostgresDriver) DropDatabase(u *url.URL) error {
 	name := databaseName(u)
 	fmt.Printf("Dropping: %s\n", name)
 
@@ -125,8 +132,8 @@ func (drv PostgresDriver) DropDatabase(u *url.URL) error {
 	return err
 }
 
-func (drv PostgresDriver) postgresSchemaMigrationsDump(db *sql.DB) ([]byte, error) {
-	migrationsTable, err := drv.migrationsTableName(db)
+func (drv *PostgresDriver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	migrationsTable, err := drv.quotedMigrationsTableName(db)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +159,7 @@ func (drv PostgresDriver) postgresSchemaMigrationsDump(db *sql.DB) ([]byte, erro
 }
 
 // DumpSchema returns the current database schema
-func (drv PostgresDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
+func (drv *PostgresDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 	// load schema
 	args := append([]string{"--format=plain", "--encoding=UTF8", "--schema-only",
 		"--no-privileges", "--no-owner"}, normalizePostgresURLForDump(u)...)
@@ -161,7 +168,7 @@ func (drv PostgresDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 		return nil, err
 	}
 
-	migrations, err := drv.postgresSchemaMigrationsDump(db)
+	migrations, err := drv.schemaMigrationsDump(db)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +178,7 @@ func (drv PostgresDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 }
 
 // DatabaseExists determines whether the database exists
-func (drv PostgresDriver) DatabaseExists(u *url.URL) (bool, error) {
+func (drv *PostgresDriver) DatabaseExists(u *url.URL) (bool, error) {
 	name := databaseName(u)
 
 	db, err := drv.openPostgresDB(u)
@@ -191,48 +198,45 @@ func (drv PostgresDriver) DatabaseExists(u *url.URL) (bool, error) {
 }
 
 // CreateMigrationsTable creates the schema_migrations table
-func (drv PostgresDriver) CreateMigrationsTable(u *url.URL, db *sql.DB) error {
-	// get schema from URL search_path param
-	searchPath := strings.Split(u.Query().Get("search_path"), ",")
-	urlSchema := strings.TrimSpace(searchPath[0])
-	if urlSchema == "" {
-		urlSchema = "public"
-	}
-
-	// get *unquoted* current schema from database
-	dbSchema, err := queryRow(db, "select current_schema()")
+func (drv *PostgresDriver) CreateMigrationsTable(u *url.URL, db *sql.DB) error {
+	schema, migrationsTable, err := drv.quotedMigrationsTableNameParts(db, u)
 	if err != nil {
 		return err
 	}
 
-	// if urlSchema and dbSchema are not equal, the most likely explanation is that the schema
-	// has not yet been created
-	if urlSchema != dbSchema {
-		// in theory we could just execute this statement every time, but we do the comparison
-		// above in case the user doesn't have permissions to create schemas and the schema
-		// already exists
-		fmt.Printf("Creating schema: %s\n", urlSchema)
-		_, err = db.Exec("create schema if not exists " + pq.QuoteIdentifier(urlSchema))
-		if err != nil {
-			return err
-		}
+	// first attempt at creating migrations table
+	createTableStmt := fmt.Sprintf("create table if not exists %s.%s", schema, migrationsTable) +
+		" (version varchar(255) primary key)"
+	_, err = db.Exec(createTableStmt)
+	if err == nil {
+		// table exists or created successfully
+		return nil
 	}
 
-	migrationsTable, err := drv.migrationsTableName(db)
+	// catch 'schema does not exist' error
+	pqErr, ok := err.(*pq.Error)
+	if !ok || pqErr.Code != "3F000" {
+		// unknown error
+		return err
+	}
+
+	// in theory we could attempt to create the schema every time, but we avoid that
+	// in case the user doesn't have permissions to create schemas
+	fmt.Printf("Creating schema: %s\n", schema)
+	_, err = db.Exec(fmt.Sprintf("create schema if not exists %s", schema))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Exec("create table if not exists " + migrationsTable +
-		" (version varchar(255) primary key)")
-
+	// second and final attempt at creating migrations table
+	_, err = db.Exec(createTableStmt)
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	migrationsTable, err := drv.migrationsTableName(db)
+func (drv *PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
+	migrationsTable, err := drv.quotedMigrationsTableName(db)
 	if err != nil {
 		return nil, err
 	}
@@ -266,8 +270,8 @@ func (drv PostgresDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bo
 }
 
 // InsertMigration adds a new migration record
-func (drv PostgresDriver) InsertMigration(db Transaction, version string) error {
-	migrationsTable, err := drv.migrationsTableName(db)
+func (drv *PostgresDriver) InsertMigration(db Transaction, version string) error {
+	migrationsTable, err := drv.quotedMigrationsTableName(db)
 	if err != nil {
 		return err
 	}
@@ -278,8 +282,8 @@ func (drv PostgresDriver) InsertMigration(db Transaction, version string) error 
 }
 
 // DeleteMigration removes a migration record
-func (drv PostgresDriver) DeleteMigration(db Transaction, version string) error {
-	migrationsTable, err := drv.migrationsTableName(db)
+func (drv *PostgresDriver) DeleteMigration(db Transaction, version string) error {
+	migrationsTable, err := drv.quotedMigrationsTableName(db)
 	if err != nil {
 		return err
 	}
@@ -291,7 +295,7 @@ func (drv PostgresDriver) DeleteMigration(db Transaction, version string) error 
 
 // Ping verifies a connection to the database server. It does not verify whether the
 // specified database exists.
-func (drv PostgresDriver) Ping(u *url.URL) error {
+func (drv *PostgresDriver) Ping(u *url.URL) error {
 	// attempt connection to primary database, not "postgres" database
 	// to support servers with no "postgres" database
 	// (see https://github.com/amacneil/dbmate/issues/78)
@@ -306,7 +310,7 @@ func (drv PostgresDriver) Ping(u *url.URL) error {
 		return nil
 	}
 
-	// ignore 'database "foo" does not exist' error
+	// ignore 'database does not exist' error
 	pqErr, ok := err.(*pq.Error)
 	if ok && pqErr.Code == "3D000" {
 		return nil
@@ -315,17 +319,53 @@ func (drv PostgresDriver) Ping(u *url.URL) error {
 	return err
 }
 
-func (drv PostgresDriver) migrationsTableName(db Transaction) (string, error) {
-	// get current schema
-	schema, err := queryRow(db, "select quote_ident(current_schema())")
+func (drv *PostgresDriver) quotedMigrationsTableName(db Transaction) (string, error) {
+	schema, name, err := drv.quotedMigrationsTableNameParts(db, nil)
 	if err != nil {
 		return "", err
 	}
 
-	// if the search path is empty, or does not contain a valid schema, default to public
+	return schema + "." + name, nil
+}
+
+func (drv *PostgresDriver) quotedMigrationsTableNameParts(db Transaction, u *url.URL) (string, string, error) {
+	schema := ""
+	tableNameParts := strings.Split(drv.migrationsTableName, ".")
+	if len(tableNameParts) > 1 {
+		// schema specified as part of table name
+		schema, tableNameParts = tableNameParts[0], tableNameParts[1:]
+	}
+
+	if schema == "" && u != nil {
+		// no schema specified with table name, try URL search path if available
+		searchPath := strings.Split(u.Query().Get("search_path"), ",")
+		schema = strings.TrimSpace(searchPath[0])
+	}
+
+	var err error
+	if schema == "" {
+		// if no URL available, use current schema
+		// this is a hack because we don't always have the URL context available
+		schema, err = queryValue(db, "select current_schema()")
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	// fall back to public schema as last resort
 	if schema == "" {
 		schema = "public"
 	}
 
-	return schema + ".schema_migrations", nil
+	// quote all parts
+	// use server rather than client to do this to avoid unnecessary quotes
+	// (which would change schema.sql diff)
+	tableNameParts = append([]string{schema}, tableNameParts...)
+	quotedNameParts, err := queryColumn(db, "select quote_ident(unnest($1::text[]))", pq.Array(tableNameParts))
+	if err != nil {
+		return "", "", err
+	}
+
+	// if more than one part, we already have a schema
+	return quotedNameParts[0], strings.Join(quotedNameParts[1:], "."), nil
 }

--- a/pkg/dbmate/sqlite.go
+++ b/pkg/dbmate/sqlite.go
@@ -11,16 +11,19 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3" // sqlite driver for database/sql
 )
 
 func init() {
-	RegisterDriver(SQLiteDriver{}, "sqlite")
-	RegisterDriver(SQLiteDriver{}, "sqlite3")
+	drv := &SQLiteDriver{}
+	RegisterDriver(drv, "sqlite")
+	RegisterDriver(drv, "sqlite3")
 }
 
 // SQLiteDriver provides top level database functions
 type SQLiteDriver struct {
+	migrationsTableName string
 }
 
 func sqlitePath(u *url.URL) string {
@@ -31,13 +34,18 @@ func sqlitePath(u *url.URL) string {
 	return str
 }
 
+// SetMigrationsTableName sets the schema migrations table name
+func (drv *SQLiteDriver) SetMigrationsTableName(name string) {
+	drv.migrationsTableName = name
+}
+
 // Open creates a new database connection
-func (drv SQLiteDriver) Open(u *url.URL) (*sql.DB, error) {
+func (drv *SQLiteDriver) Open(u *url.URL) (*sql.DB, error) {
 	return sql.Open("sqlite3", sqlitePath(u))
 }
 
 // CreateDatabase creates the specified database
-func (drv SQLiteDriver) CreateDatabase(u *url.URL) error {
+func (drv *SQLiteDriver) CreateDatabase(u *url.URL) error {
 	fmt.Printf("Creating: %s\n", sqlitePath(u))
 
 	db, err := drv.Open(u)
@@ -50,7 +58,7 @@ func (drv SQLiteDriver) CreateDatabase(u *url.URL) error {
 }
 
 // DropDatabase drops the specified database (if it exists)
-func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
+func (drv *SQLiteDriver) DropDatabase(u *url.URL) error {
 	path := sqlitePath(u)
 	fmt.Printf("Dropping: %s\n", path)
 
@@ -65,36 +73,39 @@ func (drv SQLiteDriver) DropDatabase(u *url.URL) error {
 	return os.Remove(path)
 }
 
-func sqliteSchemaMigrationsDump(db *sql.DB) ([]byte, error) {
+func (drv *SQLiteDriver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	migrationsTable := drv.quotedMigrationsTableName()
+
 	// load applied migrations
 	migrations, err := queryColumn(db,
-		"select quote(version) from schema_migrations order by version asc")
+		fmt.Sprintf("select quote(version) from %s order by version asc", migrationsTable))
 	if err != nil {
 		return nil, err
 	}
 
-	// build schema_migrations table data
+	// build schema migrations table data
 	var buf bytes.Buffer
 	buf.WriteString("-- Dbmate schema migrations\n")
 
 	if len(migrations) > 0 {
-		buf.WriteString("INSERT INTO schema_migrations (version) VALUES\n  (" +
-			strings.Join(migrations, "),\n  (") +
-			");\n")
+		buf.WriteString(
+			fmt.Sprintf("INSERT INTO %s (version) VALUES\n  (", migrationsTable) +
+				strings.Join(migrations, "),\n  (") +
+				");\n")
 	}
 
 	return buf.Bytes(), nil
 }
 
 // DumpSchema returns the current database schema
-func (drv SQLiteDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
+func (drv *SQLiteDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 	path := sqlitePath(u)
 	schema, err := runCommand("sqlite3", path, ".schema")
 	if err != nil {
 		return nil, err
 	}
 
-	migrations, err := sqliteSchemaMigrationsDump(db)
+	migrations, err := drv.schemaMigrationsDump(db)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +115,7 @@ func (drv SQLiteDriver) DumpSchema(u *url.URL, db *sql.DB) ([]byte, error) {
 }
 
 // DatabaseExists determines whether the database exists
-func (drv SQLiteDriver) DatabaseExists(u *url.URL) (bool, error) {
+func (drv *SQLiteDriver) DatabaseExists(u *url.URL) (bool, error) {
 	_, err := os.Stat(sqlitePath(u))
 	if os.IsNotExist(err) {
 		return false, nil
@@ -116,18 +127,19 @@ func (drv SQLiteDriver) DatabaseExists(u *url.URL) (bool, error) {
 	return true, nil
 }
 
-// CreateMigrationsTable creates the schema_migrations table
-func (drv SQLiteDriver) CreateMigrationsTable(u *url.URL, db *sql.DB) error {
-	_, err := db.Exec("create table if not exists schema_migrations " +
-		"(version varchar(255) primary key)")
+// CreateMigrationsTable creates the schema migrations table
+func (drv *SQLiteDriver) CreateMigrationsTable(u *url.URL, db *sql.DB) error {
+	_, err := db.Exec(
+		fmt.Sprintf("create table if not exists %s ", drv.quotedMigrationsTableName()) +
+			"(version varchar(255) primary key)")
 
 	return err
 }
 
 // SelectMigrations returns a list of applied migrations
 // with an optional limit (in descending order)
-func (drv SQLiteDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
-	query := "select version from schema_migrations order by version desc"
+func (drv *SQLiteDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool, error) {
+	query := fmt.Sprintf("select version from %s order by version desc", drv.quotedMigrationsTableName())
 	if limit >= 0 {
 		query = fmt.Sprintf("%s limit %d", query, limit)
 	}
@@ -156,15 +168,19 @@ func (drv SQLiteDriver) SelectMigrations(db *sql.DB, limit int) (map[string]bool
 }
 
 // InsertMigration adds a new migration record
-func (drv SQLiteDriver) InsertMigration(db Transaction, version string) error {
-	_, err := db.Exec("insert into schema_migrations (version) values (?)", version)
+func (drv *SQLiteDriver) InsertMigration(db Transaction, version string) error {
+	_, err := db.Exec(
+		fmt.Sprintf("insert into %s (version) values (?)", drv.quotedMigrationsTableName()),
+		version)
 
 	return err
 }
 
 // DeleteMigration removes a migration record
-func (drv SQLiteDriver) DeleteMigration(db Transaction, version string) error {
-	_, err := db.Exec("delete from schema_migrations where version = ?", version)
+func (drv *SQLiteDriver) DeleteMigration(db Transaction, version string) error {
+	_, err := db.Exec(
+		fmt.Sprintf("delete from %s where version = ?", drv.quotedMigrationsTableName()),
+		version)
 
 	return err
 }
@@ -172,7 +188,7 @@ func (drv SQLiteDriver) DeleteMigration(db Transaction, version string) error {
 // Ping verifies a connection to the database. Due to the way SQLite works, by
 // testing whether the database is valid, it will automatically create the database
 // if it does not already exist.
-func (drv SQLiteDriver) Ping(u *url.URL) error {
+func (drv *SQLiteDriver) Ping(u *url.URL) error {
 	db, err := drv.Open(u)
 	if err != nil {
 		return err
@@ -180,4 +196,15 @@ func (drv SQLiteDriver) Ping(u *url.URL) error {
 	defer mustClose(db)
 
 	return db.Ping()
+}
+
+func (drv *SQLiteDriver) quotedMigrationsTableName() string {
+	return drv.quoteIdentifier(drv.migrationsTableName)
+}
+
+// quoteIdentifier quotes a table or column name
+// we fall back to lib/pq implementation since both use ansi standard (double quotes)
+// and mattn/go-sqlite3 doesn't provide a sqlite-specific equivalent
+func (drv *SQLiteDriver) quoteIdentifier(s string) string {
+	return pq.QuoteIdentifier(s)
 }

--- a/pkg/dbmate/utils.go
+++ b/pkg/dbmate/utils.go
@@ -104,8 +104,8 @@ func trimLeadingSQLComments(data []byte) ([]byte, error) {
 // queryColumn runs a SQL statement and returns a slice of strings
 // it is assumed that the statement returns only one column
 // e.g. schema_migrations table
-func queryColumn(db Transaction, query string) ([]string, error) {
-	rows, err := db.Query(query)
+func queryColumn(db Transaction, query string, args ...interface{}) ([]string, error) {
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -128,12 +128,12 @@ func queryColumn(db Transaction, query string) ([]string, error) {
 	return result, nil
 }
 
-// queryRow runs a SQL statement and returns a single string
+// queryValue runs a SQL statement and returns a single string
 // it is assumed that the statement returns only one row and one column
 // sql NULL is returned as empty string
-func queryRow(db Transaction, query string) (string, error) {
+func queryValue(db Transaction, query string, args ...interface{}) (string, error) {
 	var result sql.NullString
-	err := db.QueryRow(query).Scan(&result)
+	err := db.QueryRow(query, args...).Scan(&result)
 	if err != nil || !result.Valid {
 		return "", err
 	}

--- a/pkg/dbmate/utils_test.go
+++ b/pkg/dbmate/utils_test.go
@@ -1,9 +1,11 @@
 package dbmate
 
 import (
+	"database/sql"
 	"net/url"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +34,25 @@ func TestTrimLeadingSQLComments(t *testing.T) {
 	out, err := trimLeadingSQLComments([]byte(in))
 	require.NoError(t, err)
 	require.Equal(t, "real stuff\n-- end\n", string(out))
+}
+
+func TestQueryColumn(t *testing.T) {
+	u := postgresTestURL(t)
+	db, err := sql.Open("postgres", u.String())
+	require.NoError(t, err)
+
+	val, err := queryColumn(db, "select concat('foo_', unnest($1::text[]))",
+		pq.Array([]string{"hi", "there"}))
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo_hi", "foo_there"}, val)
+}
+
+func TestQueryValue(t *testing.T) {
+	u := postgresTestURL(t)
+	db, err := sql.Open("postgres", u.String())
+	require.NoError(t, err)
+
+	val, err := queryValue(db, "select $1::int + $2::int", "5", 2)
+	require.NoError(t, err)
+	require.Equal(t, "7", val)
 }


### PR DESCRIPTION
Supported via `--migrations-table` CLI flag or `DBMATE_MIGRATIONS_TABLE` environment variable.

Specified table name is quoted when necessary.

For PostgreSQL specifically, it's also possible to specify a custom schema (for example: `--migrations-table=foo.migrations`).

Closes https://github.com/amacneil/dbmate/issues/168