### PR TITLE
Support embedding the migrations into the binary with go1.16 io/fs.FS

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -347,7 +347,11 @@ func (db *DB) migrate(drv Driver) error {
 
 		fmt.Printf("Applying: %s\n", filename)
 
-		up, _, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
+		contents, err := ioutil.ReadFile(filepath.Join(db.MigrationsDir, filename))
+		if err != nil {
+			return err
+		}
+		up, _, err := parseMigrationContents(string(contents))
 		if err != nil {
 			return err
 		}
@@ -487,7 +491,11 @@ func (db *DB) Rollback() error {
 
 	fmt.Printf("Rolling back: %s\n", filename)
 
-	_, down, err := parseMigration(filepath.Join(db.MigrationsDir, filename))
+	contents, err := ioutil.ReadFile(filepath.Join(db.MigrationsDir, filename))
+	if err != nil {
+		return err
+	}
+	_, down, err := parseMigrationContents(string(contents))
 	if err != nil {
 		return err
 	}

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -311,7 +311,7 @@ func (db *DB) Migrate() error {
 }
 
 func (db *DB) migrate(drv Driver) error {
-	files, err := findMigrationFiles(db.MigrationsDir, migrationFileRegexp)
+	files, err := db.findMigrationFiles(migrationFileRegexp)
 	if err != nil {
 		return err
 	}
@@ -401,10 +401,10 @@ func printVerbose(result sql.Result) {
 	}
 }
 
-func findMigrationFiles(dir string, re *regexp.Regexp) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+func (db *DB) findMigrationFiles(re *regexp.Regexp) ([]string, error) {
+	files, err := ioutil.ReadDir(db.MigrationsDir)
 	if err != nil {
-		return nil, fmt.Errorf("could not find migrations directory `%s`", dir)
+		return nil, fmt.Errorf("could not find migrations directory `%s`", db.MigrationsDir)
 	}
 
 	matches := []string{}
@@ -426,7 +426,7 @@ func findMigrationFiles(dir string, re *regexp.Regexp) ([]string, error) {
 	return matches, nil
 }
 
-func findMigrationFile(dir string, ver string) (string, error) {
+func (db *DB) findMigrationFile(ver string) (string, error) {
 	if ver == "" {
 		panic("migration version is required")
 	}
@@ -434,7 +434,7 @@ func findMigrationFile(dir string, ver string) (string, error) {
 	ver = regexp.QuoteMeta(ver)
 	re := regexp.MustCompile(fmt.Sprintf(`^%s.*\.sql$`, ver))
 
-	files, err := findMigrationFiles(dir, re)
+	files, err := db.findMigrationFiles(re)
 	if err != nil {
 		return "", err
 	}
@@ -484,7 +484,7 @@ func (db *DB) Rollback() error {
 		return fmt.Errorf("can't rollback: no migrations have been applied")
 	}
 
-	filename, err := findMigrationFile(db.MigrationsDir, latest)
+	filename, err := db.findMigrationFile(latest)
 	if err != nil {
 		return err
 	}
@@ -572,7 +572,7 @@ func (db *DB) Status(quiet bool) (int, error) {
 
 // CheckMigrationsStatus returns the status of all available mgirations
 func (db *DB) CheckMigrationsStatus(drv Driver) ([]StatusResult, error) {
-	files, err := findMigrationFiles(db.MigrationsDir, migrationFileRegexp)
+	files, err := db.findMigrationFiles(migrationFileRegexp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dbmate/db_116.go
+++ b/pkg/dbmate/db_116.go
@@ -1,0 +1,59 @@
+// +build go1.16
+
+package dbmate
+
+import (
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"time"
+)
+
+// DB allows dbmate actions to be performed on a specified database
+type DB struct {
+	AutoDumpSchema      bool
+	DatabaseURL         *url.URL
+	MigrationsDir       string
+	MigrationsTableName string
+	SchemaFile          string
+	Verbose             bool
+	WaitBefore          bool
+	WaitInterval        time.Duration
+	WaitTimeout         time.Duration
+	FS                  fs.FS
+}
+
+// New initializes a new dbmate database
+func New(databaseURL *url.URL) *DB {
+	return &DB{
+		AutoDumpSchema:      true,
+		DatabaseURL:         databaseURL,
+		MigrationsDir:       DefaultMigrationsDir,
+		MigrationsTableName: DefaultMigrationsTableName,
+		SchemaFile:          DefaultSchemaFile,
+		WaitBefore:          false,
+		WaitInterval:        DefaultWaitInterval,
+		WaitTimeout:         DefaultWaitTimeout,
+		FS:                  osFS{},
+	}
+}
+
+// osFS is an fs.FS implementation that just passes on to os.Open
+type osFS struct{}
+
+func (c osFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}
+
+func (db *DB) readDir(name string) ([]fs.DirEntry, error) {
+	// Clean the path to remove any leading ./
+	name = path.Clean(name)
+	return fs.ReadDir(db.FS, name)
+}
+
+func (db *DB) readFile(name string) ([]byte, error) {
+	// Clean the path to remove leading ./
+	name = path.Clean(name)
+	return fs.ReadFile(db.FS, name)
+}

--- a/pkg/dbmate/db_116_test.go
+++ b/pkg/dbmate/db_116_test.go
@@ -1,0 +1,74 @@
+// +build go1.16
+
+package dbmate_test
+
+import (
+	"github.com/amacneil/dbmate/pkg/dbutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"testing/fstest"
+)
+
+func TestMemoryFS(t *testing.T) {
+	// Test that we can do a migration backed by a MapFS
+	// The contents of these files are copied from the testdata
+	f := fstest.MapFS{
+		"db/migrations/20151129054053_test_migration.sql": &fstest.MapFile{
+			Data: []byte(`-- migrate:up
+create table users (
+  id integer,
+  name varchar(255)
+);
+insert into users (id, name) values (1, 'alice');
+
+-- migrate:down
+drop table users;
+`),
+		},
+		"db/migrations/20200227231541_test_posts.sql": &fstest.MapFile{
+			Data: []byte(`-- migrate:up
+create table posts (
+  id integer,
+  name varchar(255)
+);
+
+-- migrate:down
+drop table posts;
+`),
+		},
+	}
+
+	for _, u := range testURLs() {
+		t.Run(u.Scheme, func(t *testing.T) {
+			db := newTestDB(t, u)
+			db.FS = f
+			drv, err := db.GetDriver()
+			require.NoError(t, err)
+
+			// drop and recreate database
+			err = db.Drop()
+			require.NoError(t, err)
+			err = db.Create()
+			require.NoError(t, err)
+
+			// migrate
+			err = db.Migrate()
+			require.NoError(t, err)
+
+			// verify results
+			sqlDB, err := drv.Open()
+			require.NoError(t, err)
+			defer dbutil.MustClose(sqlDB)
+
+			count := 0
+			err = sqlDB.QueryRow(`select count(*) from schema_migrations
+				where version = '20151129054053'`).Scan(&count)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+
+			err = sqlDB.QueryRow("select count(*) from users").Scan(&count)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+		})
+	}
+}

--- a/pkg/dbmate/db_pre116.go
+++ b/pkg/dbmate/db_pre116.go
@@ -1,0 +1,45 @@
+// +build !go1.16
+
+package dbmate
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"time"
+)
+
+// DB allows dbmate actions to be performed on a specified database
+type DB struct {
+	AutoDumpSchema      bool
+	DatabaseURL         *url.URL
+	MigrationsDir       string
+	MigrationsTableName string
+	SchemaFile          string
+	Verbose             bool
+	WaitBefore          bool
+	WaitInterval        time.Duration
+	WaitTimeout         time.Duration
+}
+
+// New initializes a new dbmate database
+func New(databaseURL *url.URL) *DB {
+	return &DB{
+		AutoDumpSchema:      true,
+		DatabaseURL:         databaseURL,
+		MigrationsDir:       DefaultMigrationsDir,
+		MigrationsTableName: DefaultMigrationsTableName,
+		SchemaFile:          DefaultSchemaFile,
+		WaitBefore:          false,
+		WaitInterval:        DefaultWaitInterval,
+		WaitTimeout:         DefaultWaitTimeout,
+	}
+}
+
+func (db *DB) readDir(path string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(path)
+}
+
+func (db *DB) readFile(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -2,7 +2,6 @@ package dbmate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"strings"
 )
@@ -29,16 +28,6 @@ type Migration struct {
 // NewMigration constructs a Migration object
 func NewMigration() Migration {
 	return Migration{Contents: "", Options: make(migrationOptions)}
-}
-
-// parseMigration reads a migration file and returns (up Migration, down Migration, error)
-func parseMigration(path string) (Migration, Migration, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return NewMigration(), NewMigration(), err
-	}
-	up, down, err := parseMigrationContents(string(data))
-	return up, down, err
 }
 
 var upRegExp = regexp.MustCompile(`(?m)^--\s*migrate:up(\s*$|\s+\S+)`)


### PR DESCRIPTION
I made this PR backwards-compatible, so it still uses the old ways of reading files and directories pre-1.16.

I've made this PR a draft until go 1.16 is released

Resolves #193 