### PR TITLE
mysql: Use url.PathUnescape instead of url.QueryEscape so that '+' in passwords works

### DIFF
--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -52,7 +52,7 @@ func connectionString(u *url.URL) string {
 
 	// Get decoded user:pass
 	userPassEncoded := u.User.String()
-	userPass, _ := url.QueryUnescape(userPassEncoded)
+	userPass, _ := url.PathUnescape(userPassEncoded)
 
 	// Build DSN w/ user:pass percent-decoded
 	normalizedString := ""

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -78,21 +78,16 @@ func TestConnectionString(t *testing.T) {
 		require.Equal(t, "duhfsd7s:123!@123!@@tcp(host:123)/foo?flag=on&multiStatements=true", s)
 	})
 
-	// This test ensure that a connection string provided by a user containing URL encoded
-	// characters is properly passed on to the MySQL driver. The MySQL driver expects a plain
-	// password string, so the user-provided encoded URL be decoded.
-	//
-	// Special care is required here with '+' (encoded by user to '%2B'), since it can be decoded in two ways:
-	// - url.QueryUnescape will result in incorrect ' ' (a single space) being passed to the driver
-	// - url.PathUnescape will result in the correct '+' being passed to the driver
 	t.Run("url encoding", func(t *testing.T) {
-		u, err := url.Parse("mysql://bob%2Balice%3Asecret%5E%5B%2A%28%29@host:123/foo")
+		u, err := url.Parse("mysql://bob%2Balice:secret%5E%5B%2A%28%29@host:123/foo")
 		require.NoError(t, err)
-		require.Equal(t, "bob+alice:secret^[*()", u.User)
+		require.Equal(t, "bob+alice:secret%5E%5B%2A%28%29", u.User.String())
 		require.Equal(t, "123", u.Port())
 
 		s := connectionString(u)
-		require.Equal(t, "bob+alice:secret^[*()@tcp(host:123)/foo", s)
+		// ensure that '+' is correctly encoded by url.PathUnescape as '+'
+		// (not whitespace as url.QueryUnescape generates)
+		require.Equal(t, "bob+alice:secret^[*()@tcp(host:123)/foo?multiStatements=true", s)
 	})
 
 	t.Run("socket", func(t *testing.T) {


### PR DESCRIPTION
This addresses #199 which I just opened. As the [documentation][pathunescape] says:

> PathUnescape is identical to QueryUnescape except that it does not unescape '+' to ' ' (space).

I think that makes sense, since `+` in passwords gets converted to a space otherwise, and this isn't correct.

[pathunescape]: https://golang.org/pkg/net/url/#PathUnescape