### PR TITLE
make the "invalid url" error message give more information

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -72,7 +72,7 @@ func New(databaseURL *url.URL) *DB {
 // GetDriver initializes the appropriate database driver
 func (db *DB) GetDriver() (Driver, error) {
 	if db.DatabaseURL == nil || db.DatabaseURL.Scheme == "" {
-		return nil, errors.New("invalid url, have you set your --url flag or DATABASE_HOST environment variable?")
+		return nil, errors.New("invalid url, have you set your --url flag or DATABASE_URL environment variable?")
 	}
 
 	driverFunc := drivers[db.DatabaseURL.Scheme]

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -72,7 +72,7 @@ func New(databaseURL *url.URL) *DB {
 // GetDriver initializes the appropriate database driver
 func (db *DB) GetDriver() (Driver, error) {
 	if db.DatabaseURL == nil || db.DatabaseURL.Scheme == "" {
-		return nil, errors.New("invalid url")
+		return nil, errors.New("invalid url, have you set your --url flag or DATABASE_HOST environment variable?")
 	}
 
 	driverFunc := drivers[db.DatabaseURL.Scheme]

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -55,14 +55,14 @@ func TestGetDriver(t *testing.T) {
 		db := dbmate.New(nil)
 		drv, err := db.GetDriver()
 		require.Nil(t, drv)
-		require.EqualError(t, err, "invalid url")
+		require.EqualError(t, err, "invalid url, have you set your --url flag or DATABASE_URL environment variable?")
 	})
 
 	t.Run("missing schema", func(t *testing.T) {
 		db := dbmate.New(dbutil.MustParseURL("//hi"))
 		drv, err := db.GetDriver()
 		require.Nil(t, drv)
-		require.EqualError(t, err, "invalid url")
+		require.EqualError(t, err, "invalid url, have you set your --url flag or DATABASE_URL environment variable?")
 	})
 
 	t.Run("invalid driver", func(t *testing.T) {


### PR DESCRIPTION
make the "invalid url" error message give more information for somebody that hasn't ready documentation and just runs the application

**Input**

```sh
dbmate up
```
**Output**

```
Error: invalid url, have you set your --url flag or DATABASE_HOST environment variable?
```