### PR TITLE
[First Draft] postgre: add more error information to an error message (position, line number, partial SQL)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -372,9 +372,14 @@ func (db *DB) migrate(drv Driver) error {
 						return errors.Wrapf(err, "pos: %v", pqErr.Position)
 					}
 					// compute line number manually as pq driver does not provide it
+					column := 0
 					lineCount := 0
+					itColumn := 0
 					for _, c := range up.Contents[:pos] {
+						itColumn++
 						if c == '\n' {
+							column = itColumn
+							itColumn = 0
 							lineCount++
 						}
 					}
@@ -388,7 +393,7 @@ func (db *DB) migrate(drv Driver) error {
 						maxPos = len(up.Contents) - 1
 					}
 					areaOfFailure := up.Contents[minPos:maxPos]
-					return errors.Wrapf(err, "pos: %v, line: %v, sql: %s\n", pqErr.Position, lineCount, areaOfFailure)
+					return errors.Wrapf(err, "position: %v, line: %v, column: %v, sql: %s\n", pqErr.Position, lineCount, column, areaOfFailure)
 				}
 				return err
 			} else if db.Verbose {

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -13,10 +13,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/amacneil/dbmate/pkg/dbutil"
+
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 )
 
 // DefaultMigrationsDir specifies default directory to find migration files


### PR DESCRIPTION
Hey there!

This is a proof-of-concept PR to see if we can improve error reporting as per issue: https://github.com/amacneil/dbmate/issues/102

I understand that this isn't the nicest code approach as of yet and that we may want to maybe move this into the `dbutil` package or similar and also look at having tests for error behaviour.

**Sample migration file:**
```sql
-- migrate:up
CREATE TABLE test (
    test_id uuid NOT NULL
);
COMMENT ON TABLE test IS 'Here is my test table';

CREATE TABLE test_mistake (
    -- uh oh, comma here on the last field, error!
    test_mistake_id uuid NOT NULL,
);

-- migrate:down
DROP TABLE test;
DROP TABLE test_mistake;
```

**Error messages previously:**
```
pq: syntax error at or near "CREATE"
```

**Errors messages after PR:**
```sh
Error: position: 229, line: 9, column: 35, sql: field, error!
    test_mistake_id uuid NOT NULL,
);

: pq: syntax error at or near ")"
```