### PR TITLE
Publish Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ on:
 
 jobs:
   build:
-    name: Build & Test
+    name: Build
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -54,7 +55,19 @@ jobs:
           docker-compose run --rm dev make wait
           docker-compose run --rm dev make test
 
-      - name: Release
+      - name: Publish docker image
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          SRC_IMAGE: dbmate_release
+          DOCKERHUB_IMAGE: ${{ github.repository }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/workflows/publish-docker.sh
+
+      - name: Publish release binaries
         uses: softprops/action-gh-release@v1
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:

--- a/.github/workflows/publish-docker.sh
+++ b/.github/workflows/publish-docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Tag and publish Docker image
+
+set -euo pipefail
+
+echo "$DOCKERHUB_TOKEN" | (set -x && docker login --username "$DOCKERHUB_USERNAME" --password-stdin)
+echo "$GHCR_TOKEN" | (set -x && docker login ghcr.io --username "$GHCR_USERNAME" --password-stdin)
+
+# Tag and push docker image
+function docker_push {
+    src=$1
+    dst=$2
+    echo  # newline
+
+    (
+        set -x
+        docker tag "$src" "$dst"
+        docker push "$dst"
+    )
+}
+
+# Publish image to both Docker Hub and GitHub Container Registry
+function publish {
+    tag=$1
+    docker_push "$SRC_IMAGE" "$DOCKERHUB_IMAGE:$tag"
+    docker_push "$SRC_IMAGE" "$GHCR_IMAGE:$tag"
+}
+
+# Publish current branch/tag (e.g. `main` or `v1.2.3`)
+ver=${GITHUB_REF##*/}
+publish "$ver"
+
+# Publish major/minor/latest for version tags
+if [[ "$GITHUB_REF" = refs/tags/v* ]]; then
+    major_ver=${ver%%.*}  # e.g. `v1`
+    publish "$major_ver"
+
+    minor_ver=${ver%.*}  # e.g. `v1.2`
+    publish "$minor_ver"
+
+    publish "latest"
+fi
+
+# Clear credentials
+rm -f ~/.docker/config.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
   "go.formatTool": "goimports"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     build:
       context: .
       target: release
+    image: dbmate_release
 
   mysql:
     image: mysql:5.7


### PR DESCRIPTION
Docker Hub no longer supports free container builds for open source.

Publish to both Docker Hub and GitHub Container Registry.