### PR TITLE
Postgres defaults to unix socket with no host

### DIFF
--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"runtime"
 	"strings"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
@@ -48,7 +49,14 @@ func connectionString(u *url.URL) string {
 
 	// default hostname
 	if hostname == "" {
-		query.Set("host", "/var/run/postgresql")
+		switch runtime.GOOS {
+		case "windows":
+			hostname = "localhost"
+		case "linux":
+			query.Set("host", "/var/run/postgresql")
+		default:
+			query.Set("host", "/tmp")
+		}
 	}
 
 	// host param overrides url hostname

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -50,12 +50,12 @@ func connectionString(u *url.URL) string {
 	// default hostname
 	if hostname == "" {
 		switch runtime.GOOS {
-		case "windows":
-			hostname = "localhost"
 		case "linux":
 			query.Set("host", "/var/run/postgresql")
-		default:
+		case "darwin", "freebsd", "dragonfly", "openbsd", "netbsd":
 			query.Set("host", "/tmp")
+		default:
+			hostname = "localhost"
 		}
 	}
 

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -48,7 +48,7 @@ func connectionString(u *url.URL) string {
 
 	// default hostname
 	if hostname == "" {
-		hostname = "localhost"
+		query.Set("host", "/var/run/postgresql")
 	}
 
 	// host param overrides url hostname

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -56,7 +56,7 @@ func TestConnectionString(t *testing.T) {
 		expected string
 	}{
 		// defaults
-		{"postgres:///foo", "postgres://localhost:5432/foo"},
+		{"postgres:///foo", "postgres://:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"},
 		// support custom url params
 		{"postgres://bob:secret@myhost:1234/foo?bar=baz", "postgres://bob:secret@myhost:1234/foo?bar=baz"},
 		// support `host` and `port` via url params
@@ -85,11 +85,11 @@ func TestConnectionArgsForDump(t *testing.T) {
 		expected []string
 	}{
 		// defaults
-		{"postgres:///foo", []string{"postgres://localhost:5432/foo"}},
+		{"postgres:///foo", []string{"postgres://:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"}},
 		// support single schema
-		{"postgres:///foo?search_path=foo", []string{"--schema", "foo", "postgres://localhost:5432/foo"}},
+		{"postgres:///foo?search_path=foo", []string{"--schema", "foo", "postgres://:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"}},
 		// support multiple schemas
-		{"postgres:///foo?search_path=foo,public", []string{"--schema", "foo", "--schema", "public", "postgres://localhost:5432/foo"}},
+		{"postgres:///foo?search_path=foo,public", []string{"--schema", "foo", "--schema", "public", "postgres://:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"}},
 	}
 
 	for _, c := range cases {

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -53,12 +53,12 @@ func TestGetDriver(t *testing.T) {
 
 func defaultConnString() string {
 	switch runtime.GOOS {
-	case "windows":
-		return "postgres://localhost:5432/foo"
 	case "linux":
 		return "postgres://:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"
-	default:
+	case "darwin", "freebsd", "dragonfly", "openbsd", "netbsd":
 		return "postgres://:5432/foo?host=%2Ftmp"
+	default:
+		return "postgres://localhost:5432/foo"
 	}
 }
 


### PR DESCRIPTION
Closes #229

When there's no host given in a postgres connection url, use the unix
domain default socket. Previously, the default was a localhost TCP
connection. This default behavior is more in line with standard postgres
clients out there, like psql.