### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -226,7 +225,7 @@ func (db *DB) dumpSchema(drv Driver) error {
 	}
 
 	// write schema to file
-	return ioutil.WriteFile(db.SchemaFile, schema, 0644)
+	return os.WriteFile(db.SchemaFile, schema, 0644)
 }
 
 // ensureDir creates a directory if it does not already exist
@@ -402,7 +401,7 @@ func (db *DB) printVerbose(result sql.Result) {
 }
 
 func findMigrationFiles(dir string, re *regexp.Regexp) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("could not find migrations directory `%s`", dir)
 	}

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -1,7 +1,6 @@
 package dbmate_test
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func TestDumpSchema(t *testing.T) {
 	db := newTestDB(t, u)
 
 	// create custom schema file directory
-	dir, err := ioutil.TempDir("", "dbmate")
+	dir, err := os.MkdirTemp("", "dbmate")
 	require.NoError(t, err)
 	defer func() {
 		err := os.RemoveAll(dir)
@@ -129,7 +128,7 @@ func TestDumpSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify schema
-	schema, err := ioutil.ReadFile(db.SchemaFile)
+	schema, err := os.ReadFile(db.SchemaFile)
 	require.NoError(t, err)
 	require.Contains(t, string(schema), "-- PostgreSQL database dump")
 }
@@ -140,7 +139,7 @@ func TestAutoDumpSchema(t *testing.T) {
 	db.AutoDumpSchema = true
 
 	// create custom schema file directory
-	dir, err := ioutil.TempDir("", "dbmate")
+	dir, err := os.MkdirTemp("", "dbmate")
 	require.NoError(t, err)
 	defer func() {
 		err := os.RemoveAll(dir)
@@ -163,7 +162,7 @@ func TestAutoDumpSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify schema
-	schema, err := ioutil.ReadFile(db.SchemaFile)
+	schema, err := os.ReadFile(db.SchemaFile)
 	require.NoError(t, err)
 	require.Contains(t, string(schema), "-- PostgreSQL database dump")
 
@@ -176,7 +175,7 @@ func TestAutoDumpSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// schema should be recreated
-	schema, err = ioutil.ReadFile(db.SchemaFile)
+	schema, err = os.ReadFile(db.SchemaFile)
 	require.NoError(t, err)
 	require.Contains(t, string(schema), "-- PostgreSQL database dump")
 }

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -2,7 +2,7 @@ package dbmate
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -33,7 +33,7 @@ func NewMigration() Migration {
 
 // parseMigration reads a migration file and returns (up Migration, down Migration, error)
 func parseMigration(path string) (Migration, Migration, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return NewMigration(), NewMigration(), err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.