### PR TITLE
Update to MySQL 8.0 image for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ wait:
 
 .PHONY: docker-all
 docker-all:
+	docker-compose pull
 	docker-compose build
 	docker-compose run --rm dev make all
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,9 @@ services:
     image: dbmate_release
 
   mysql:
-    image: mysql:5.7
+    image: mysql/mysql-server:8.0
     environment:
+      MYSQL_ROOT_HOST: "%"
       MYSQL_ROOT_PASSWORD: root
 
   postgres:


### PR DESCRIPTION
The official `mysql:5.7` docker image does not work on arm64 (e.g. Apple M1), nor does `mysql:8.0`.

`mysql/mysql-server:8.0` appears to be maintained by Oracle and is equally "official", so switching to that for the time being.