### PR TITLE
Add ability to use timestamp format with underscore from cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following options are available with all commands. You must use command line
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `$DBMATE_NO_DUMP_SCHEMA`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `$DBMATE_WAIT`)_
 - `--wait-timeout 60s` - timeout for --wait flag _(env: `$DBMATE_WAIT_TIMEOUT`)_
+- `--timestamp-format=new` - use timestamp with underscore separating year, month, day, and time  _(env: `DBMATE_TIMESTAMP_FORMAT`)_
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -69,6 +69,13 @@ func NewApp() *cli.App {
 			Value:   dbmate.DefaultSchemaFile,
 			Usage:   "specify the schema file location",
 		},
+		&cli.StringFlag{
+			Name:    "timestamp-format",
+			Aliases: []string{"t"},
+			EnvVars: []string{"DBMATE_TIMESTAMP_FORMAT"},
+			Value:   "old",
+			Usage:   "use the new timestamp format with (old) format: 20060102150405 or (new): 2006_01_02_150405",
+		},
 		&cli.BoolFlag{
 			Name:    "no-dump-schema",
 			EnvVars: []string{"DBMATE_NO_DUMP_SCHEMA"},
@@ -235,6 +242,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		db.MigrationsTableName = c.String("migrations-table")
 		db.SchemaFile = c.String("schema-file")
 		db.WaitBefore = c.Bool("wait")
+		db.TimestampFormat = c.String("timestamp-format")
 		overrideTimeout := c.Duration("wait-timeout")
 		if overrideTimeout != 0 {
 			db.WaitTimeout = overrideTimeout

--- a/pkg/dbutil/sort.go
+++ b/pkg/dbutil/sort.go
@@ -1,0 +1,108 @@
+package dbutil
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultTimestampLayout specifies previous default timestamp with YYYYMMDDtime format
+const DefaultTimestampLayout = "20060102150405"
+
+// NewTimestampLayout specifies timestamp with YYYY_MM_DD_time format
+const NewTimestampLayout = "2006_01_02_150405"
+
+// DefaultTimestampSeparator specifies new timestamp separator
+const DefaultTimestampSeparator = "_"
+
+// TimeSlice holds a slice of File for the purpose of sorting
+type TimeSlice []File
+
+// File stores information regarding a migration file
+type File struct {
+	Timestamp         time.Time
+	OriginalTimestamp string
+	Name              string
+	Description       string
+}
+
+func (p TimeSlice) Len() int {
+	return len(p)
+}
+
+func (p TimeSlice) Less(i, j int) bool {
+	return p[i].Timestamp.Before(p[j].Timestamp)
+}
+
+func (p TimeSlice) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+// SortByDate picks the timestamp part of the file whether it is using the old
+// or new format, and sort them chronologically.
+func SortByDate(matches []string) (sorted []string, err error) {
+	timestamps := make(TimeSlice, 0, len(sorted))
+
+	for _, match := range matches {
+		timestamp, description, found := Cut(match, DefaultTimestampSeparator)
+		if !found {
+			return nil, errors.New("unable to find timestamp")
+		}
+		var parsed time.Time
+		if len(timestamp) == len(DefaultTimestampLayout) {
+			// Handles previous timestamp format which is 14 characters long
+			p, err := time.Parse(DefaultTimestampLayout, timestamp)
+			if err != nil {
+				return nil, err
+			}
+			parsed = p
+		} else if len(timestamp) == len(NewTimestampLayout) {
+			// Handles new timestamp format which is 17 characters long
+			p, err := time.Parse(NewTimestampLayout, timestamp)
+			if err != nil {
+				return nil, err
+			}
+			parsed = p
+		}
+
+		timestamps = append(timestamps, File{
+			Timestamp:         parsed,
+			OriginalTimestamp: timestamp,
+			Description:       description,
+			Name:              match,
+		})
+	}
+
+	// Len(), Less(), and Swap() are custom implemented and satisfy
+	// sort.Interface
+	sort.Sort(timestamps)
+
+	for _, timestamp := range timestamps {
+		sorted = append(sorted, timestamp.Name)
+	}
+
+	return sorted, nil
+}
+
+func Cut(val string, separator string) (timestamp, description string, found bool) {
+	split := strings.Split(val, separator)
+	if len(split) > 1 {
+		if len(split[0]) == len(DefaultTimestampLayout) {
+			timestamp = split[0]
+			description = strings.Join(split[1:], "_")
+		} else if len(split[0]) == 4 { // equal to YYYY
+			timestamp = split[0] + DefaultTimestampSeparator +
+				split[1] + DefaultTimestampSeparator +
+				split[2] + DefaultTimestampSeparator +
+				split[3]
+			description = strings.Join(split[4:], "_")
+		} else {
+			return "", "", false
+		}
+	} else {
+		return "", "", false
+	}
+
+	return timestamp, description, true
+}

--- a/pkg/dbutil/sort_test.go
+++ b/pkg/dbutil/sort_test.go
@@ -1,0 +1,125 @@
+package dbutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortByDate(t *testing.T) {
+	tests := []struct {
+		name          string
+		filenameInput []string
+		wantSorted    []string
+		wantErr       bool
+	}{
+		{
+			name: "Old format",
+			filenameInput: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"20211231054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantSorted: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"20211231054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Old format unordered",
+			filenameInput: []string{
+				"20211231071240_create_tenants_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"20211231054630_create_user_role_table.sql",
+				"20211231054532_create_users_table.sql",
+			},
+			wantSorted: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"20211231054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Mixed old and new format",
+			filenameInput: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantSorted: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Mixed old and new format unordered",
+			filenameInput: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"20211231071240_create_tenants_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+			},
+			wantSorted: []string{
+				"20211231054532_create_users_table.sql",
+				"20211231054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"20211231071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+		{
+			name: "All new format",
+			filenameInput: []string{
+				"2021_12_31_054532_create_users_table.sql",
+				"2021_12_31_054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"2021_12_31_071240_create_tenants_table.sql",
+			},
+			wantSorted: []string{
+				"2021_12_31_054532_create_users_table.sql",
+				"2021_12_31_054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"2021_12_31_071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+		{
+			name: "All new format unordered",
+			filenameInput: []string{
+				"2021_12_31_071240_create_tenants_table.sql",
+				"2021_12_31_054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"2021_12_31_054532_create_users_table.sql",
+			},
+			wantSorted: []string{
+				"2021_12_31_054532_create_users_table.sql",
+				"2021_12_31_054537_create_roles_table.sql",
+				"2021_12_31_054630_create_user_role_table.sql",
+				"2021_12_31_071240_create_tenants_table.sql",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSorted, err := SortByDate(tt.filenameInput)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SortByDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotSorted, tt.wantSorted) {
+				t.Errorf("SortByDate() gotSorted = %v, want %v", gotSorted, tt.wantSorted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Based on https://github.com/amacneil/dbmate/issues/252.

Reading timestamp that contains a separator is easier to read and find out the year, month, and day. For example:

 20211231054630_create_users_table.sql
vs
 2021_12_31_054630_create_users_table.sql