### PR TITLE
Fix whitespace issues in SQLite absolute paths in DATABASE_URL

### DIFF
--- a/pkg/dbutil/dbutil.go
+++ b/pkg/dbutil/dbutil.go
@@ -151,3 +151,18 @@ func MustParseURL(s string) *url.URL {
 
 	return u
 }
+
+// MustUnescapePath unescapes a URL path, and panics if it fails.
+// It is used during in cases where we are parsing a generated path.
+func MustUnescapePath(s string) string {
+	if s == "" {
+		panic("missing path")
+	}
+
+	path, err := url.PathUnescape(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return path
+}

--- a/pkg/driver/sqlite/sqlite.go
+++ b/pkg/driver/sqlite/sqlite.go
@@ -47,6 +47,23 @@ func ConnectionString(u *url.URL) string {
 	newURL := *u
 	newURL.Scheme = ""
 
+	if newURL.Opaque == "" && newURL.Path != "" {
+		// When the DSN is in the form "scheme:/absolute/path" or
+		// "scheme://absolute/path" or "scheme:///absolute/path", url.Parse
+		// will consider the file path as :
+		// - "absolute" as the hostname
+		// - "path" (and the rest until "?") as the URL path.
+		// Instead, when the DSN is in the form "scheme:", the (relative) file
+		// path is stored in the "Opaque" field.
+		// See: https://pkg.go.dev/net/url#URL
+		//
+		// While Opaque is not escaped, the URL Path is. So, if .Path contains
+		// the file path, we need to un-escape it, and rebuild the full path.
+
+		newURL.Opaque = "//" + newURL.Host + dbutil.MustUnescapePath(newURL.Path)
+		newURL.Path = ""
+	}
+
 	// trim duplicate leading slashes
 	str := regexp.MustCompile("^//+").ReplaceAllString(newURL.String(), "/")
 

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -58,6 +58,16 @@ func TestConnectionString(t *testing.T) {
 		require.Equal(t, "foo/bar.sqlite3?mode=ro", ConnectionString(u))
 	})
 
+	t.Run("relative with dot", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:./foo/bar.sqlite3?mode=ro")
+		require.Equal(t, "./foo/bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("relative with double dot", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:../foo/bar.sqlite3?mode=ro")
+		require.Equal(t, "../foo/bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
 	t.Run("absolute", func(t *testing.T) {
 		u := dbutil.MustParseURL("sqlite:/tmp/foo.sqlite3?mode=ro")
 		require.Equal(t, "/tmp/foo.sqlite3?mode=ro", ConnectionString(u))
@@ -74,6 +84,45 @@ func TestConnectionString(t *testing.T) {
 		// supported for backwards compatibility
 		u := dbutil.MustParseURL("sqlite:////tmp/foo.sqlite3?mode=ro")
 		require.Equal(t, "/tmp/foo.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("relative with space", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:foo bar.sqlite3?mode=ro")
+		require.Equal(t, "foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("relative with space and dot", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:./foo bar.sqlite3?mode=ro")
+		require.Equal(t, "./foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("relative with space and double dot", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:../foo bar.sqlite3?mode=ro")
+		require.Equal(t, "../foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("absolute with space", func(t *testing.T) {
+		u := dbutil.MustParseURL("sqlite:/foo bar.sqlite3?mode=ro")
+		require.Equal(t, "/foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("three slashes with space in path", func(t *testing.T) {
+		// interpreted as absolute path
+		u := dbutil.MustParseURL("sqlite:///tmp/foo bar.sqlite3?mode=ro")
+		require.Equal(t, "/tmp/foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("three slashes with space in path (1st dir)", func(t *testing.T) {
+		// interpreted as absolute path
+		u := dbutil.MustParseURL("sqlite:///tm p/foo bar.sqlite3?mode=ro")
+		require.Equal(t, "/tm p/foo bar.sqlite3?mode=ro", ConnectionString(u))
+	})
+
+	t.Run("four slashes with space", func(t *testing.T) {
+		// interpreted as absolute path
+		// supported for backwards compatibility
+		u := dbutil.MustParseURL("sqlite:////tmp/foo bar.sqlite3?mode=ro")
+		require.Equal(t, "/tmp/foo bar.sqlite3?mode=ro", ConnectionString(u))
 	})
 }
 

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -182,7 +182,7 @@ func TestSQLiteDumpSchema(t *testing.T) {
 	schema, err = drv.DumpSchema(db)
 	require.Nil(t, schema)
 	require.Error(t, err)
-	require.EqualError(t, err, "Error: unable to open database \".\": "+
+	require.EqualError(t, err, "Error: unable to open database \"/.\": "+
 		"unable to open database file")
 }
 


### PR DESCRIPTION
When the DSN is in the form `sqlite:/absolute/path` or `sqlite://absolute/path` or `sqlite:///absolute/path`, url.Parse
will consider the file path as:
 - `absolute` as the hostname
 - `path` (and the rest until `?`) as the URL path.
Instead, when the DSN is in the form "sqlite:", the (relative) file path is stored in the "Opaque" field.
See: https://pkg.go.dev/net/url#URL

While Opaque is not escaped, the URL Path is. So, in absolute paths the full file path is being escaped as if it was an URL path.
This commit works around this behavior in `ConnectionString()` (`sqlite.go`) so that the return string is always a correct (url-unescaped) file path.

Fixes #264 .