### PR TITLE
#285 Add support for multi-statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,18 @@ ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 
 `transaction` will default to `true` if your database supports it.
 
+**multi-statement**
+
+`multi-statement` is useful if you need to run some SQL which cannot be executed from within a block. For example, in Postgres, you would need to run create index concurrently statements on its own, same can be achieved by having a single create index concurrently statement by setting transaction off:
+
+```sql
+-- migrate:up multi-statement:true
+create table users (id serial, name text);
+create index concurrently index_users_on_id on users(id);
+```
+
+`multi-statement` will default to `false`.
+
 ### Waiting For The Database
 
 If you use a Docker development environment for your project, you may encounter issues with the database not being immediately ready when running migrations or unit tests. This can be due to the database server having only just started.

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -355,7 +355,7 @@ func (db *DB) migrate(drv Driver) error {
 			return err
 		}
 
-		execMigrationStmt := func (tx dbutil.Transaction, stmt string, final bool) error {
+		execMigrationStmt := func(tx dbutil.Transaction, stmt string, final bool) error {
 			// run actual migration
 			result, err := tx.Exec(stmt)
 			if err != nil {

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -21,7 +21,7 @@ func (m migrationOptions) Transaction() bool {
 	return m["transaction"] != "false"
 }
 
-// MultiStatement returns wheter or not this migration should run statement by statement
+// MultiStatement returns whether or not this migration should run statement by statement
 // Defaults to false.
 func (m migrationOptions) MultiStatement() bool {
 	if val, ok := m["multi-statement"]; ok {

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -10,6 +10,7 @@ import (
 // MigrationOptions is an interface for accessing migration options
 type MigrationOptions interface {
 	Transaction() bool
+	MultiStatement() bool
 }
 
 type migrationOptions map[string]string
@@ -18,6 +19,16 @@ type migrationOptions map[string]string
 // Defaults to true.
 func (m migrationOptions) Transaction() bool {
 	return m["transaction"] != "false"
+}
+
+// MultiStatement returns wheter or not this migration should run statement by statement
+// Defaults to false.
+func (m migrationOptions) MultiStatement() bool {
+	if val, ok := m["multi-statement"]; ok {
+		return val != "true"
+	}
+
+	return false
 }
 
 // Migration contains the migration contents and options


### PR DESCRIPTION
Multi Statement support for running migration script statement by statement. This is to support running multiple statements e.g. create index concurrently in postgresql in a single migration file.