### PR TITLE
Move sqlite driver import behind build constraint

### DIFF
--- a/drivers.go
+++ b/drivers.go
@@ -1,0 +1,7 @@
+package main
+
+import (
+	_ "github.com/amacneil/dbmate/pkg/driver/clickhouse"
+	_ "github.com/amacneil/dbmate/pkg/driver/mysql"
+	_ "github.com/amacneil/dbmate/pkg/driver/postgres"
+)

--- a/drivers_cgo.go
+++ b/drivers_cgo.go
@@ -1,0 +1,8 @@
+//go:build cgo
+// +build cgo
+
+package main
+
+import (
+	_ "github.com/amacneil/dbmate/pkg/driver/sqlite"
+)

--- a/main.go
+++ b/main.go
@@ -11,10 +11,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
-	_ "github.com/amacneil/dbmate/pkg/driver/clickhouse"
-	_ "github.com/amacneil/dbmate/pkg/driver/mysql"
-	_ "github.com/amacneil/dbmate/pkg/driver/postgres"
-	_ "github.com/amacneil/dbmate/pkg/driver/sqlite"
 )
 
 func main() {


### PR DESCRIPTION
This moves the database driver imports into separate files:
* one for sqlite with cgo build constraint and
* one for all the others.

This makes it possible to compile dbmate without sqlite again.

Fixes #284