### PR TITLE
Do not discard host parameter in postgresql URLs

### DIFF
--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -61,7 +61,7 @@ func connectionString(u *url.URL) string {
 
 	// host param overrides url hostname
 	if query.Get("host") != "" {
-		hostname = ""
+		hostname = query.Get("host")
 	}
 
 	// always specify a port


### PR DESCRIPTION
It currently seems to be impossible to specify a socket path other than the default.