### PR TITLE
Include `mariadb-connector-c` (#307)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN make build
 FROM alpine as release
 RUN apk add --no-cache \
 	mariadb-client \
-    mariadb-connector-c \
+	mariadb-connector-c \
 	postgresql-client \
 	sqlite \
 	tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN make build
 FROM alpine as release
 RUN apk add --no-cache \
 	mariadb-client \
+    mariadb-connector-c \
 	postgresql-client \
 	sqlite \
 	tzdata


### PR DESCRIPTION
This makes it so that the `caching_sha2_password `  plugin is included so connections to Mysql > 8.0 can succeed.

fixes: #307 