### PR TITLE
Add support for statement timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func NewApp() *cli.App {
 			EnvVars:  []string{"STATEMENT_TIMEOUT"},
 			Usage:    "the executing statement timeout",
 			Required: false,
-			Value:    dbmate.DefaultStatementTimeout,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -81,6 +81,13 @@ func NewApp() *cli.App {
 			Usage:   "timeout for --wait flag",
 			Value:   dbmate.DefaultWaitTimeout,
 		},
+		&cli.DurationFlag{
+			Name:     "statement-timeout",
+			EnvVars:  []string{"STATEMENT_TIMEOUT"},
+			Usage:    "the executing statement timeout",
+			Required: false,
+			Value:    dbmate.DefaultStatementTimeout,
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -234,6 +241,10 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		overrideTimeout := c.Duration("wait-timeout")
 		if overrideTimeout != 0 {
 			db.WaitTimeout = overrideTimeout
+		}
+		overrideStatementTimeout := c.Duration("statement-timeout")
+		if overrideStatementTimeout != 0 {
+			db.StatementTimeout = overrideStatementTimeout
 		}
 
 		return f(db, c)

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -42,6 +42,7 @@ var (
 	ErrMigrationDirNotFound  = errors.New("could not find migrations directory")
 	ErrMigrationNotFound     = errors.New("can't find migration file")
 	ErrCreateDirectory       = errors.New("unable to create directory")
+	ErrFeatureNotImplemented = errors.New("this feature is not implemented for this database")
 )
 
 // DB allows dbmate actions to be performed on a specified database

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -358,6 +358,12 @@ func (db *DB) migrate(drv Driver) error {
 		return err
 	}
 
+	if db.StatementTimeout != 0 {
+		err = drv.IncreaseStatementTimeout(sqlDB, db.StatementTimeout)
+		if err != nil && err != ErrFeatureNotImplemented {
+			return err
+		}
+	}
 	for _, filename := range files {
 		ver := migrationVersion(filename)
 		if ok := applied[ver]; ok {

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -56,6 +56,7 @@ type DB struct {
 	WaitBefore          bool
 	WaitInterval        time.Duration
 	WaitTimeout         time.Duration
+	StatementTimeout    time.Duration
 	Log                 io.Writer
 }
 
@@ -79,6 +80,7 @@ func New(databaseURL *url.URL) *DB {
 		WaitBefore:          false,
 		WaitInterval:        DefaultWaitInterval,
 		WaitTimeout:         DefaultWaitTimeout,
+		StatementTimeout:    DefaultStatementTimeout,
 		Log:                 os.Stdout,
 	}
 }

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -80,7 +80,6 @@ func New(databaseURL *url.URL) *DB {
 		WaitBefore:          false,
 		WaitInterval:        DefaultWaitInterval,
 		WaitTimeout:         DefaultWaitTimeout,
-		StatementTimeout:    DefaultStatementTimeout,
 		Log:                 os.Stdout,
 	}
 }

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"io"
 	"net/url"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbutil"
 )
@@ -21,6 +22,7 @@ type Driver interface {
 	InsertMigration(dbutil.Transaction, string) error
 	DeleteMigration(dbutil.Transaction, string) error
 	Ping() error
+	IncreaseStatementTimeout(*sql.DB, time.Duration) error
 }
 
 // DriverConfig holds configuration passed to driver constructors

--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -334,6 +335,10 @@ func (drv *Driver) Ping() error {
 	}
 
 	return err
+}
+
+func (drv *Driver) IncreaseStatementTimeout(db *sql.DB, timeout time.Duration) error {
+	return dbmate.ErrFeatureNotImplemented
 }
 
 func (drv *Driver) quotedMigrationsTableName() string {

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -349,6 +350,17 @@ func TestClickHousePing(t *testing.T) {
 	err = drv.Ping()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connect: connection refused")
+}
+
+func TestStatementTimeout(t *testing.T) {
+	drv := testClickHouseDriver(t)
+
+	db := prepTestClickHouseDB(t)
+	defer dbutil.MustClose(db)
+
+	err := drv.IncreaseStatementTimeout(db, time.Minute)
+	require.Error(t, err)
+	require.EqualValues(t, dbmate.ErrFeatureNotImplemented, err)
 }
 
 func TestClickHouseQuotedMigrationsTableName(t *testing.T) {

--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -296,6 +297,10 @@ func (drv *Driver) Ping() error {
 	defer dbutil.MustClose(db)
 
 	return db.Ping()
+}
+
+func (drv *Driver) IncreaseStatementTimeout(db *sql.DB, timeout time.Duration) error {
+	return dbmate.ErrFeatureNotImplemented
 }
 
 func (drv *Driver) quotedMigrationsTableName() string {

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -333,6 +334,17 @@ func TestMySQLPing(t *testing.T) {
 	err = drv.Ping()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connect: connection refused")
+}
+
+func TestStatementTimeout(t *testing.T) {
+	drv := testMySQLDriver(t)
+
+	db := prepTestMySQLDB(t)
+	defer dbutil.MustClose(db)
+
+	err := drv.IncreaseStatementTimeout(db, time.Minute)
+	require.Error(t, err)
+	require.EqualValues(t, dbmate.ErrFeatureNotImplemented, err)
 }
 
 func TestMySQLQuotedMigrationsTableName(t *testing.T) {

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/url"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -358,6 +360,11 @@ func (drv *Driver) Ping() error {
 		return nil
 	}
 
+	return err
+}
+
+func (drv *Driver) IncreaseStatementTimeout(db *sql.DB, timeout time.Duration) error {
+	_, err := db.Exec(fmt.Sprintf("SET statement_timeout = %s", strconv.Itoa(int(timeout.Milliseconds()))))
 	return err
 }
 

--- a/pkg/driver/sqlite/sqlite.go
+++ b/pkg/driver/sqlite/sqlite.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -241,6 +242,10 @@ func (drv *Driver) Ping() error {
 	defer dbutil.MustClose(db)
 
 	return db.Ping()
+}
+
+func (drv *Driver) IncreaseStatementTimeout(db *sql.DB, timeout time.Duration) error {
+	return dbmate.ErrFeatureNotImplemented
 }
 
 func (drv *Driver) quotedMigrationsTableName() string {

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
 	"github.com/amacneil/dbmate/pkg/dbutil"
@@ -379,6 +380,17 @@ func TestSQLitePing(t *testing.T) {
 	// ping database should fail
 	err = drv.Ping()
 	require.EqualError(t, err, "unable to open database file: is a directory")
+}
+
+func TestStatementTimeout(t *testing.T) {
+	drv := testSQLiteDriver(t)
+
+	db := prepTestSQLiteDB(t)
+	defer dbutil.MustClose(db)
+
+	err := drv.IncreaseStatementTimeout(db, time.Minute)
+	require.Error(t, err)
+	require.EqualValues(t, dbmate.ErrFeatureNotImplemented, err)
 }
 
 func TestSQLiteQuotedMigrationsTableName(t *testing.T) {


### PR DESCRIPTION
# Context

When running migrations, some statements might take a little bit longer which results in a statement timeout which is usually either a default value or a global value set in some configuration file.

What we want is to be able to modify this default statement timeout according to our needs.

# Solution approach

A CLI flag of `--statement-timeout` has been added to provide the user the ability of passing a custom statement timeout.

# Caveats

Even though modifications are on the interface level, currently an implementation for statement timeout is only provided for PostgresSQL since this is the database I am familiar with and easily have access to.
For other supported databases (clickhouse, mysql, sqlite), the `--statement-timeout` has no effect.

In case there's enough interest in this work, I can put some time for the other databases (clickhouse, mysql, sqlite)