### PR TITLE
WIP: Add support for Go embedded file system

### DIFF
--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/amacneil/dbmate/pkg/dbmate"
@@ -369,7 +370,7 @@ func TestRollback(t *testing.T) {
 	}
 }
 
-func TestStatus(t *testing.T) {
+func TestFindMigrations(t *testing.T) {
 	for _, u := range testURLs() {
 		t.Run(u.Scheme, func(t *testing.T) {
 			db := newTestDB(t, u)
@@ -388,7 +389,7 @@ func TestStatus(t *testing.T) {
 			defer dbutil.MustClose(sqlDB)
 
 			// two pending
-			results, err := db.CheckMigrationsStatus()
+			results, err := db.FindMigrations()
 			require.NoError(t, err)
 			require.Len(t, results, 2)
 			require.False(t, results[0].Applied)
@@ -402,7 +403,7 @@ func TestStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			// two applied
-			results, err = db.CheckMigrationsStatus()
+			results, err = db.FindMigrations()
 			require.NoError(t, err)
 			require.Len(t, results, 2)
 			require.True(t, results[0].Applied)
@@ -413,11 +414,65 @@ func TestStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			// one applied, one pending
-			results, err = db.CheckMigrationsStatus()
+			results, err = db.FindMigrations()
 			require.NoError(t, err)
 			require.Len(t, results, 2)
 			require.True(t, results[0].Applied)
 			require.False(t, results[1].Applied)
 		})
 	}
+}
+
+func TestFindMigrationsFS(t *testing.T) {
+	mapFS := fstest.MapFS{
+		"db/migrations/20151129054053_test_migration.sql": {},
+		"db/migrations/001_test_migration.sql": {
+			Data: []byte(`-- migrate:up
+create table users (id serial, name text);
+-- migrate:down
+drop table users;
+`),
+		},
+		"db/migrations/002_test_migration.sql":                {},
+		"db/migrations/003_not_sql.txt":                       {},
+		"db/migrations/missing_version.sql":                   {},
+		"db/not_migrations/20151129054053_test_migration.sql": {},
+	}
+
+	u := dbutil.MustParseURL(os.Getenv("POSTGRES_TEST_URL"))
+	db := newTestDB(t, u)
+	db.FS = mapFS
+
+	// drop and recreate database
+	err := db.Drop()
+	require.NoError(t, err)
+	err = db.Create()
+	require.NoError(t, err)
+
+	actual, err := db.FindMigrations()
+	require.NoError(t, err)
+
+	// test migrations are correct and in order
+	require.Equal(t, "001_test_migration.sql", actual[0].FileName)
+	require.Equal(t, "db/migrations/001_test_migration.sql", actual[0].FilePath)
+	require.Equal(t, "001", actual[0].Version)
+	require.Equal(t, false, actual[0].Applied)
+
+	require.Equal(t, "002_test_migration.sql", actual[1].FileName)
+	require.Equal(t, "db/migrations/002_test_migration.sql", actual[1].FilePath)
+	require.Equal(t, "002", actual[1].Version)
+	require.Equal(t, false, actual[1].Applied)
+
+	require.Equal(t, "20151129054053_test_migration.sql", actual[2].FileName)
+	require.Equal(t, "db/migrations/20151129054053_test_migration.sql", actual[2].FilePath)
+	require.Equal(t, "20151129054053", actual[2].Version)
+	require.Equal(t, false, actual[2].Applied)
+
+	// test parsing first migration
+	parsed, err := actual[0].Parse()
+	require.Nil(t, err)
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.True(t, parsed.UpOptions.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.True(t, parsed.DownOptions.Transaction())
 }

--- a/pkg/dbmate/migration_test.go
+++ b/pkg/dbmate/migration_test.go
@@ -2,9 +2,38 @@ package dbmate
 
 import (
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestParse(t *testing.T) {
+	fs := fstest.MapFS{
+		"bar/123_foo.sql": {
+			Data: []byte(`-- migrate:up
+create table users (id serial, name text);
+-- migrate:down
+drop table users;
+`),
+		},
+	}
+
+	migration := &Migration{
+		Applied:  false,
+		FileName: "123_foo.sql",
+		FilePath: "bar/123_foo.sql",
+		FS:       fs,
+		Version:  "123",
+	}
+
+	parsed, err := migration.Parse()
+	require.Nil(t, err)
+	require.Same(t, migration, parsed.Migration)
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.True(t, parsed.UpOptions.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.True(t, parsed.DownOptions.Transaction())
+}
 
 func TestParseMigrationContents(t *testing.T) {
 	// It supports the typical use case.
@@ -13,14 +42,14 @@ create table users (id serial, name text);
 -- migrate:down
 drop table users;`
 
-	up, down, err := parseMigrationContents(migration)
+	parsed, err := parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does not require space between the '--' and 'migrate'
 	migration = `
@@ -31,14 +60,14 @@ create table users (id serial, name text);
 drop table users;
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "--migrate:up\ncreate table users (id serial, name text);\n\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "--migrate:up\ncreate table users (id serial, name text);\n\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "--migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "--migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It is acceptable for down to be defined before up
 	migration = `-- migrate:down
@@ -47,14 +76,14 @@ drop table users;
 create table users (id serial, name text);
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It supports turning transactions off for a given migration block,
 	// e.g., the below would not work in Postgres inside a transaction.
@@ -63,21 +92,21 @@ create table users (id serial, name text);
 ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up transaction:false\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\n", up.Contents)
-	require.Equal(t, false, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up transaction:false\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\n", parsed.Up)
+	require.Equal(t, false, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does *not* support omitting the up block.
 	migration = `-- migrate:down
 drop table users;
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate requires each migration to define an up block with '-- migrate:up'", err.Error())
 
@@ -93,14 +122,14 @@ create table users (id serial, name text);
 drop table users;
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does *not* allow arbitrary statements preceding the migrate blocks
 	migration = `
@@ -116,7 +145,7 @@ ALTER TABLE users
 DROP COLUMN status;
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate does not support statements defined outside of the '-- migrate:up' or '-- migrate:down' blocks", err.Error())
 
@@ -126,7 +155,7 @@ ALTER TABLE users
 ADD COLUMN status status_type DEFAULT 'active';
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate requires each migration to define an up block with '-- migrate:up'", err.Error())
 }


### PR DESCRIPTION
This commit adds the support for fs.FS filesystem. The default value is an implementation that forwards `Open()` to `os.Open()` for opening filesystem paths (like before this change).

This is a rebase/rework of the previous branch by @bouk

WIP:

* [ ] Add instructions in README.md
* [ ] Add examples
