### PR TITLE
Fix create db and upgrade clickhouse-server to v22.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,4 @@ services:
       POSTGRES_PASSWORD: postgres
 
   clickhouse:
-    image: yandex/clickhouse-server:19.16
+    image: clickhouse/clickhouse-server:22.8

--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -143,7 +143,7 @@ func (drv *Driver) DropDatabase() error {
 func (drv *Driver) schemaDump(db *sql.DB, buf *bytes.Buffer, databaseName string) error {
 	buf.WriteString("\n--\n-- Database schema\n--\n\n")
 
-	buf.WriteString("CREATE DATABASE " + drv.quoteIdentifier(databaseName) + " IF NOT EXISTS;\n\n")
+	buf.WriteString("CREATE DATABASE IF NOT EXISTS" + drv.quoteIdentifier(databaseName) + ";\n\n")
 
 	tables, err := dbutil.QueryColumn(db, "show tables")
 	if err != nil {

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -180,7 +180,11 @@ func TestClickHouseDatabaseExists_Error(t *testing.T) {
 	drv.databaseURL.RawQuery = values.Encode()
 
 	exists, err := drv.DatabaseExists()
-	require.EqualError(t, err, "code: 192, message: Unknown user invalid")
+	require.EqualError(
+		t,
+		err,
+		"code: 516, message: invalid: Authentication failed: password is incorrect or there is no user with such name",
+	)
 	require.Equal(t, false, exists)
 }
 
@@ -193,7 +197,11 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 		// migrations table should not exist
 		count := 0
 		err := db.QueryRow("select count(*) from schema_migrations").Scan(&count)
-		require.EqualError(t, err, "code: 60, message: Table dbmate_test.schema_migrations doesn't exist.")
+		require.EqualError(
+			t,
+			err,
+			"code: 60, message: Table dbmate_test.schema_migrations doesn't exist",
+		)
 
 		// create table
 		err = drv.CreateMigrationsTable(db)
@@ -218,7 +226,11 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 		// migrations table should not exist
 		count := 0
 		err := db.QueryRow("select count(*) from \"testMigrations\"").Scan(&count)
-		require.EqualError(t, err, "code: 60, message: Table dbmate_test.testMigrations doesn't exist.")
+		require.EqualError(
+			t,
+			err,
+			"code: 60, message: Table dbmate_test.testMigrations doesn't exist",
+		)
 
 		// create table
 		err = drv.CreateMigrationsTable(db)


### PR DESCRIPTION
- Upgraded `clickhouse-server` image to v22.8 the latest LTS version
  - Updated the tests since the error messages are different in v22
- Fixed `CREATE DATABASE IF NOT EXISTS` based on the official document https://github.com/amacneil/dbmate/issues/379