### PR TITLE
Fix: Docker Test CI errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 COPY go.* /src/
 RUN go mod download
 COPY . /src/
+ENV GO_ADDITIONAL_FLAGS="-buildvcs=false"
 RUN make build
 
 # release stage

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ ifeq ($(GOOS),windows)
 	endif
 endif
 
+FLAGS += $(GO_ADDITIONAL_FLAGS)
+
 .PHONY: all
 all: fix build wait test
 


### PR DESCRIPTION
I am trying to resolve the VCS tagging issue in the CI pipline.

The change in Go is documented here: https://go.dev/doc/go1.18. I am unsure why this is failing in the pipeline when it works locally running the same commands.