### PR TITLE
Clickhouse: Fix CheckMigrationTableExists

### DIFF
--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -233,7 +233,7 @@ func (drv *Driver) DatabaseExists() (bool, error) {
 // MigrationsTableExists checks if the schema_migrations table exists
 func (drv *Driver) MigrationsTableExists(db *sql.DB) (bool, error) {
 	exists := false
-	err := db.QueryRow("EXISTS TABLE $1", drv.quotedMigrationsTableName()).
+	err := db.QueryRow(fmt.Sprintf("EXISTS TABLE %s", drv.quotedMigrationsTableName())).
 		Scan(&exists)
 	if err == sql.ErrNoRows {
 		return false, nil

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -205,6 +205,7 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 
 		// use driver function to check the same as above
 		exists, err := drv.MigrationsTableExists(db)
+		require.NoError(t, err)
 		require.Equal(t, false, exists)
 
 		// create table
@@ -243,6 +244,7 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 
 		// use driver function to check the same as above
 		exists, err := drv.MigrationsTableExists(db)
+		require.NoError(t, err)
 		require.Equal(t, false, exists)
 
 		// create table

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -203,6 +203,10 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 			"code: 60, message: Table dbmate_test.schema_migrations doesn't exist",
 		)
 
+		// use driver function to check the same as above
+		exists, err := drv.MigrationsTableExists(db)
+		require.Equal(t, false, exists)
+
 		// create table
 		err = drv.CreateMigrationsTable(db)
 		require.NoError(t, err)
@@ -210,6 +214,11 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 		// migrations table should exist
 		err = db.QueryRow("select count(*) from schema_migrations").Scan(&count)
 		require.NoError(t, err)
+
+		// use driver function to check the same as above
+		exists, err = drv.MigrationsTableExists(db)
+		require.NoError(t, err)
+		require.Equal(t, true, exists)
 
 		// create table should be idempotent
 		err = drv.CreateMigrationsTable(db)
@@ -232,6 +241,10 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 			"code: 60, message: Table dbmate_test.testMigrations doesn't exist",
 		)
 
+		// use driver function to check the same as above
+		exists, err := drv.MigrationsTableExists(db)
+		require.Equal(t, false, exists)
+
 		// create table
 		err = drv.CreateMigrationsTable(db)
 		require.NoError(t, err)
@@ -239,6 +252,11 @@ func TestClickHouseCreateMigrationsTable(t *testing.T) {
 		// migrations table should exist
 		err = db.QueryRow("select count(*) from \"testMigrations\"").Scan(&count)
 		require.NoError(t, err)
+
+		// use driver function to check the same as above
+		exists, err = drv.MigrationsTableExists(db)
+		require.NoError(t, err)
+		require.Equal(t, true, exists)
 
 		// create table should be idempotent
 		err = drv.CreateMigrationsTable(db)


### PR DESCRIPTION
Checking for the migration tables existence in Clickhouse shouldn't pass a parameter.

This could be acheived one of two ways:

- Use Sprintf to add the table name to the query (this is what is used elsewhere within the Clickhouse driver)
- Check the `information_schema` using `currentDatabase()`.

Opted for the first as that is what is used elsewhere.

Fixes #301 