### PR TITLE
Support embedded filesystem migrations

### DIFF
--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -2,13 +2,40 @@ package dbmate
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"regexp"
 	"strings"
 )
 
-// MigrationOptions is an interface for accessing migration options
-type MigrationOptions interface {
+// Migration represents an available migration and status
+type Migration struct {
+	Applied  bool
+	FileName string
+	FilePath string
+	FS       fs.FS
+	Version  string
+}
+
+// Parse a migration
+func (m *Migration) Parse() (*ParsedMigration, error) {
+	bytes, err := fs.ReadFile(m.FS, m.FilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseMigrationContents(string(bytes))
+}
+
+// ParsedMigration contains the migration contents and options
+type ParsedMigration struct {
+	Up          string
+	UpOptions   ParsedMigrationOptions
+	Down        string
+	DownOptions ParsedMigrationOptions
+}
+
+// ParsedMigrationOptions is an interface for accessing migration options
+type ParsedMigrationOptions interface {
 	Transaction() bool
 }
 
@@ -18,27 +45,6 @@ type migrationOptions map[string]string
 // Defaults to true.
 func (m migrationOptions) Transaction() bool {
 	return m["transaction"] != "false"
-}
-
-// Migration contains the migration contents and options
-type Migration struct {
-	Contents string
-	Options  MigrationOptions
-}
-
-// NewMigration constructs a Migration object
-func NewMigration() Migration {
-	return Migration{Contents: "", Options: make(migrationOptions)}
-}
-
-// parseMigration reads a migration file and returns (up Migration, down Migration, error)
-func parseMigration(path string) (Migration, Migration, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return NewMigration(), NewMigration(), err
-	}
-	up, down, err := parseMigrationContents(string(data))
-	return up, down, err
 }
 
 var (
@@ -62,17 +68,14 @@ var (
 // block and the second representing the "down" block. This function
 // requires that at least an up block was defined and will otherwise
 // return an error.
-func parseMigrationContents(contents string) (Migration, Migration, error) {
-	up := NewMigration()
-	down := NewMigration()
-
+func parseMigrationContents(contents string) (*ParsedMigration, error) {
 	upDirectiveStart, upDirectiveEnd, hasDefinedUpBlock := getMatchPositions(contents, upRegExp)
 	downDirectiveStart, downDirectiveEnd, hasDefinedDownBlock := getMatchPositions(contents, downRegExp)
 
 	if !hasDefinedUpBlock {
-		return up, down, ErrParseMissingUp
+		return nil, ErrParseMissingUp
 	} else if statementsPrecedeMigrateBlocks(contents, upDirectiveStart, downDirectiveStart) {
-		return up, down, ErrParseUnexpectedStmt
+		return nil, ErrParseUnexpectedStmt
 	}
 
 	upEnd := len(contents)
@@ -89,13 +92,13 @@ func parseMigrationContents(contents string) (Migration, Migration, error) {
 	upDirective := substring(contents, upDirectiveStart, upDirectiveEnd)
 	downDirective := substring(contents, downDirectiveStart, downDirectiveEnd)
 
-	up.Options = parseMigrationOptions(upDirective)
-	up.Contents = substring(contents, upDirectiveStart, upEnd)
-
-	down.Options = parseMigrationOptions(downDirective)
-	down.Contents = substring(contents, downDirectiveStart, downEnd)
-
-	return up, down, nil
+	parsed := ParsedMigration{
+		Up:          substring(contents, upDirectiveStart, upEnd),
+		UpOptions:   parseMigrationOptions(upDirective),
+		Down:        substring(contents, downDirectiveStart, downEnd),
+		DownOptions: parseMigrationOptions(downDirective),
+	}
+	return &parsed, nil
 }
 
 // parseMigrationOptions parses the migration options out of a block
@@ -105,7 +108,7 @@ func parseMigrationContents(contents string) (Migration, Migration, error) {
 //
 //	fmt.Printf("%#v", parseMigrationOptions("-- migrate:up transaction:false"))
 //	// migrationOptions{"transaction": "false"}
-func parseMigrationOptions(contents string) MigrationOptions {
+func parseMigrationOptions(contents string) ParsedMigrationOptions {
 	options := make(migrationOptions)
 
 	// strip away the -- migrate:[up|down] part

--- a/pkg/dbmate/migration_test.go
+++ b/pkg/dbmate/migration_test.go
@@ -2,9 +2,37 @@ package dbmate
 
 import (
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestParse(t *testing.T) {
+	fs := fstest.MapFS{
+		"bar/123_foo.sql": {
+			Data: []byte(`-- migrate:up
+create table users (id serial, name text);
+-- migrate:down
+drop table users;
+`),
+		},
+	}
+
+	migration := &Migration{
+		Applied:  false,
+		FileName: "123_foo.sql",
+		FilePath: "bar/123_foo.sql",
+		FS:       fs,
+		Version:  "123",
+	}
+
+	parsed, err := migration.Parse()
+	require.Nil(t, err)
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.True(t, parsed.UpOptions.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.True(t, parsed.DownOptions.Transaction())
+}
 
 func TestParseMigrationContents(t *testing.T) {
 	// It supports the typical use case.
@@ -13,14 +41,14 @@ create table users (id serial, name text);
 -- migrate:down
 drop table users;`
 
-	up, down, err := parseMigrationContents(migration)
+	parsed, err := parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does not require space between the '--' and 'migrate'
 	migration = `
@@ -31,14 +59,14 @@ create table users (id serial, name text);
 drop table users;
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "--migrate:up\ncreate table users (id serial, name text);\n\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "--migrate:up\ncreate table users (id serial, name text);\n\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "--migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "--migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It is acceptable for down to be defined before up
 	migration = `-- migrate:down
@@ -47,14 +75,14 @@ drop table users;
 create table users (id serial, name text);
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It supports turning transactions off for a given migration block,
 	// e.g., the below would not work in Postgres inside a transaction.
@@ -63,21 +91,21 @@ create table users (id serial, name text);
 ALTER TYPE colors ADD VALUE 'orange' AFTER 'red';
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up transaction:false\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\n", up.Contents)
-	require.Equal(t, false, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up transaction:false\nALTER TYPE colors ADD VALUE 'orange' AFTER 'red';\n", parsed.Up)
+	require.Equal(t, false, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does *not* support omitting the up block.
 	migration = `-- migrate:down
 drop table users;
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate requires each migration to define an up block with '-- migrate:up'", err.Error())
 
@@ -93,14 +121,14 @@ create table users (id serial, name text);
 drop table users;
 `
 
-	up, down, err = parseMigrationContents(migration)
+	parsed, err = parseMigrationContents(migration)
 	require.Nil(t, err)
 
-	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n\n", up.Contents)
-	require.Equal(t, true, up.Options.Transaction())
+	require.Equal(t, "-- migrate:up\ncreate table users (id serial, name text);\n\n", parsed.Up)
+	require.Equal(t, true, parsed.UpOptions.Transaction())
 
-	require.Equal(t, "-- migrate:down\ndrop table users;\n", down.Contents)
-	require.Equal(t, true, down.Options.Transaction())
+	require.Equal(t, "-- migrate:down\ndrop table users;\n", parsed.Down)
+	require.Equal(t, true, parsed.DownOptions.Transaction())
 
 	// It does *not* allow arbitrary statements preceding the migrate blocks
 	migration = `
@@ -116,7 +144,7 @@ ALTER TABLE users
 DROP COLUMN status;
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate does not support statements defined outside of the '-- migrate:up' or '-- migrate:down' blocks", err.Error())
 
@@ -126,7 +154,7 @@ ALTER TABLE users
 ADD COLUMN status status_type DEFAULT 'active';
 `
 
-	_, _, err = parseMigrationContents(migration)
+	_, err = parseMigrationContents(migration)
 	require.NotNil(t, err)
 	require.Equal(t, "dbmate requires each migration to define an up block with '-- migrate:up'", err.Error())
 }


### PR DESCRIPTION
Support passing `fs.FS` to support embedded filesystems. Defaults to the directory filesystem.

Also cleaned up `Migration` object and parsing, and simplified `FindMigrations()` to always return the application status of each migration.

Closes https://github.com/amacneil/dbmate/issues/193
Closes https://github.com/amacneil/dbmate/pull/346