### PR TITLE
Shorter version column, use default charset for mysql

### DIFF
--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -245,8 +245,8 @@ func (drv *Driver) MigrationsTableExists(db *sql.DB) (bool, error) {
 
 // CreateMigrationsTable creates the schema_migrations table
 func (drv *Driver) CreateMigrationsTable(db *sql.DB) error {
-	_, err := db.Exec(fmt.Sprintf("create table if not exists %s "+
-		"(version varchar(255) primary key) character set latin1 collate latin1_bin",
+	_, err := db.Exec(fmt.Sprintf(
+		"create table if not exists %s (version varchar(128) primary key)",
 		drv.quotedMigrationsTableName()))
 
 	return err

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -247,8 +247,9 @@ func (drv *Driver) CreateMigrationsTable(db *sql.DB) error {
 	}
 
 	// first attempt at creating migrations table
-	createTableStmt := fmt.Sprintf("create table if not exists %s.%s", schema, migrationsTable) +
-		" (version varchar(255) primary key)"
+	createTableStmt := fmt.Sprintf(
+		"create table if not exists %s.%s (version varchar(128) primary key)",
+		schema, migrationsTable)
 	_, err = db.Exec(createTableStmt)
 	if err == nil {
 		// table exists or created successfully

--- a/pkg/driver/sqlite/sqlite.go
+++ b/pkg/driver/sqlite/sqlite.go
@@ -174,9 +174,9 @@ func (drv *Driver) MigrationsTableExists(db *sql.DB) (bool, error) {
 
 // CreateMigrationsTable creates the schema migrations table
 func (drv *Driver) CreateMigrationsTable(db *sql.DB) error {
-	_, err := db.Exec(
-		fmt.Sprintf("create table if not exists %s ", drv.quotedMigrationsTableName()) +
-			"(version varchar(255) primary key)")
+	_, err := db.Exec(fmt.Sprintf(
+		"create table if not exists %s (version varchar(128) primary key)",
+		drv.quotedMigrationsTableName()))
 
 	return err
 }


### PR DESCRIPTION
- Use default charset for mysql
- Change version column from `varchar(256)` to `varchar(128)` to avoid issues with utf8mb4 on mysql. Made this change on all drivers for consistency.

Refs:
- https://github.com/amacneil/dbmate/discussions/390
- https://github.com/amacneil/dbmate/issues/85