### PR TITLE
Fix subsequent rollbacks

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -457,9 +457,9 @@ func (db *DB) Rollback() error {
 		return err
 	}
 
-	for _, migration := range migrations {
+	for i, migration := range migrations {
 		if migration.Applied {
-			latest = &migration
+			latest = &migrations[i]
 		}
 	}
 

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -373,6 +373,19 @@ func TestRollback(t *testing.T) {
 			err = sqlDB.QueryRow("select count(*) from posts").Scan(&count)
 			require.NotNil(t, err)
 			require.Regexp(t, "(does not exist|doesn't exist|no such table)", err.Error())
+
+			// rollback second time
+			err = db.Rollback()
+			require.NoError(t, err)
+
+			// verify second rollback
+			err = sqlDB.QueryRow("select count(*) from schema_migrations").Scan(&count)
+			require.NoError(t, err)
+			require.Equal(t, 0, count)
+
+			err = sqlDB.QueryRow("select count(*) from users").Scan(&count)
+			require.NotNil(t, err)
+			require.Regexp(t, "(does not exist|doesn't exist|no such table)", err.Error())
 		})
 	}
 }


### PR DESCRIPTION
There's a small issue with a pointer that only allows one rollback to work: #404 

This PR fixes the issue and adds a second rollback in the test case to prove that it works now.

Fixes https://github.com/amacneil/dbmate/issues/404