### PR TITLE
Publish as CommonJS module

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "type": "module",
   "scripts": {
     "clean": "rimraf dist packages/dbmate/dist",
     "lint": "eslint --report-unused-disable-directives --fix .",

--- a/typescript/packages/dbmate/package.json
+++ b/typescript/packages/dbmate/package.json
@@ -15,7 +15,6 @@
     "schema",
     "sqlite"
   ],
-  "type": "module",
   "bin": "./dist/cli.js",
   "main": "./dist/index.js",
   "files": [

--- a/typescript/packages/dbmate/src/resolveBinary.ts
+++ b/typescript/packages/dbmate/src/resolveBinary.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { arch, platform } from "node:process";
 
 /**
@@ -9,7 +8,7 @@ export function resolveBinary(): string {
   const path = `@dbmate/${platform}-${arch}/bin/dbmate${ext}`;
 
   try {
-    return createRequire(import.meta.url).resolve(path);
+    return require.resolve(path);
   } catch (err) {
     if (
       err != undefined &&

--- a/typescript/packages/dbmate/tsconfig.json
+++ b/typescript/packages/dbmate/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@foxglove/tsconfig/base",
+  "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
     "rootDir": "./src",

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["*.ts"],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist"
+    "outDir": "./dist",
+    "module": "commonjs"
   }
 }


### PR DESCRIPTION
Exporting an ESM package is difficult for CommonJS consumers, and the benefits of using ESM are minimal since we only target Node.js.

Therefore, we export a CommonJS package instead (which will still work fine for all ESM Node.js consumers).