### PR TITLE
specify just a single migration to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The following options are available with all commands. You must use command line
 
 - `--url, -u "protocol://host:port/dbname"` - specify the database url directly. _(env: `DATABASE_URL`)_
 - `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
+- `--migrations, -m "VERSION"` - operate on only the single migration specified _(env: `DBMATE_MIGRATION`)_
 - `--migrations-dir, -d "./db/migrations"` - where to keep the migration files. _(env: `DBMATE_MIGRATIONS_DIR`)_
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_

--- a/main.go
+++ b/main.go
@@ -50,6 +50,12 @@ func NewApp() *cli.App {
 			Usage:   "specify an environment variable containing the database URL",
 		},
 		&cli.StringFlag{
+			Name:    "migration",
+			Aliases: []string{"m"},
+			EnvVars: []string{"DBMATE_MIGRATION"},
+			Usage:   "specify one specific migration to use",
+		},
+		&cli.StringFlag{
 			Name:    "migrations-dir",
 			Aliases: []string{"d"},
 			EnvVars: []string{"DBMATE_MIGRATIONS_DIR"},
@@ -231,6 +237,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		}
 		db := dbmate.New(u)
 		db.AutoDumpSchema = !c.Bool("no-dump-schema")
+		db.Migration = c.String("migration")
 		db.MigrationsDir = c.String("migrations-dir")
 		db.MigrationsTableName = c.String("migrations-table")
 		db.SchemaFile = c.String("schema-file")


### PR DESCRIPTION
It's not unusual for there to be multiple pending migrations but to want to carefully apply just one.
I have been forced to engage in workarounds like deleting the migration files I don't want to apply (probably most people are putting the migration file they want into a separate directory).

This was tested manually with `dbmate status`  by using the version and the filename and seeing that only one migration showed up. Also tested by using a non-existent version and seeing the error show up.