### PR TITLE
Postgres: support a connection string DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ $ dbmate -u "postgres://postgres@127.0.0.1:5432/myapp_test?sslmode=disable" up
 
 The only advantage of using `dbmate -e TEST_DATABASE_URL` over `dbmate -u $TEST_DATABASE_URL` is that the former takes advantage of dbmate's automatic `.env` file loading.
 
+Some drivers (currently just Postgres) support specifying a DSN string instead of a url by using `DATABASE_DSN` instead of `DATABBASE_URL`. When using `DATABASE_DSN` you can specify the driver with `DBMATE_DRIVER`.
+
 #### PostgreSQL
 
 When connecting to Postgres, you may need to add the `sslmode=disable` option to your connection string, as dbmate by default requires a TLS connection (some other frameworks/languages allow unencrypted connections by default).

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func NewApp() *cli.App {
 	app.Usage = "A lightweight, framework-independent database migration tool."
 	app.Version = dbmate.Version
 
-	defaultDB := dbmate.New(nil, nil)
+	defaultDB := dbmate.New(nil)
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "url",
@@ -230,7 +230,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		db := dbmate.New(u, dsn)
+		db := dbmate.NewWithDSN(u, dsn)
 		db.AutoDumpSchema = !c.Bool("no-dump-schema")
 		db.MigrationsDir = c.String("migrations-dir")
 		db.MigrationsTableName = c.String("migrations-table")

--- a/main_test.go
+++ b/main_test.go
@@ -22,19 +22,19 @@ func TestGetDatabaseUrl(t *testing.T) {
 	ctx := cli.NewContext(app, flagset, nil)
 
 	// no flags defaults to DATABASE_URL
-	u, err := getDatabaseURL(ctx)
+	u, _, err := getDatabaseConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "foo://example.org/one", u.String())
 
 	// --env overwrites DATABASE_URL
 	require.NoError(t, ctx.Set("env", "CUSTOM_URL"))
-	u, err = getDatabaseURL(ctx)
+	u, _, err = getDatabaseConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "foo://example.org/two", u.String())
 
 	// --url takes precedence over preceding two options
 	require.NoError(t, ctx.Set("url", "foo://example.org/three"))
-	u, err = getDatabaseURL(ctx)
+	u, _, err = getDatabaseConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "foo://example.org/three", u.String())
 }

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -34,7 +34,7 @@ var (
 func NewDSN(driver string, input string) (dbutil.DSN, error) {
 	dsn, err := dbutil.NewDSN(driver, input)
 	if errors.Is(err, dbutil.ErrDriverUnset) {
-		return dsn, fmt.Errorf("%w: %s expected DBMATE_DRIVER to be set or driver= in DSN", err.Error(), ErrUnsupportedDriver)
+		return dsn, fmt.Errorf("%s: expected DBMATE_DRIVER to be set or driver= in DSN: %w", err.Error(), ErrUnsupportedDriver)
 	}
 	return dsn, err
 }

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -77,7 +77,12 @@ type StatusResult struct {
 }
 
 // New initializes a new dbmate database
-func New(databaseURL *url.URL, dsn *dbutil.DSN) *DB {
+func New(databaseURL *url.URL) *DB {
+	return NewWithDSN(databaseURL, nil)
+}
+
+// NewWithDSN initializes a new dbmate database with either a url or a dsn
+func NewWithDSN(databaseURL *url.URL, dsn *dbutil.DSN) *DB {
 	return &DB{
 		AutoDumpSchema:      true,
 		DatabaseURL:         databaseURL,

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -26,6 +26,7 @@ type Driver interface {
 // DriverConfig holds configuration passed to driver constructors
 type DriverConfig struct {
 	DatabaseURL         *url.URL
+	DatabaseDSN         *dbutil.DSN
 	Log                 io.Writer
 	MigrationsTableName string
 }

--- a/pkg/dbutil/dbutil_test.go
+++ b/pkg/dbutil/dbutil_test.go
@@ -56,3 +56,42 @@ func TestQueryValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "7", val)
 }
+
+func TestDSNDriverRequired(t *testing.T) {
+	driver := "postgres"
+	connStr := "user=User dbname=DBName"
+	_, err := dbutil.NewDSN(driver, connStr)
+	require.NoError(t, err)
+	_, err = dbutil.NewDSN("", connStr)
+	require.Error(t, err)
+	_, err = dbutil.NewDSN("", connStr+" driver=postgres")
+	require.NoError(t, err)
+}
+
+func TestDSNGetKey(t *testing.T) {
+	driver := "postgres"
+	connStr := "user=User dbname=DBName"
+	dsn, err := dbutil.NewDSN(driver, connStr)
+	require.NoError(t, err)
+	require.Equal(t, connStr, dsn.ConnectionString())
+
+	userValue := dsn.GetKey("user")
+	require.Equal(t, "User", userValue)
+	dbnameValue := dsn.GetKey("dbname")
+	require.Equal(t, "DBName", dbnameValue)
+}
+
+func TestDSNDeleteKey(t *testing.T) {
+	driver := "postgres"
+	connStr := "user=User dbname=DBName"
+	dsn, err := dbutil.NewDSN(driver, connStr)
+	require.NoError(t, err)
+	require.Equal(t, connStr, dsn.ConnectionString())
+
+	userValue := dsn.DeleteKey("user")
+	require.Equal(t, "User", userValue)
+	require.Equal(t, "dbname=DBName", dsn.ConnectionString())
+	dbnameValue := dsn.DeleteKey("dbname")
+	require.Equal(t, "DBName", dbnameValue)
+	require.Equal(t, "", dsn.ConnectionString())
+}

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testPostgresDriver(t *testing.T) *Driver {
-	u := dbutil.MustParseURL(os.Getenv("POSTGRES_TEST_URL"))
+	u := dbutil.MustParseURL(os.Getenv("POSTGRES_TEST_URL"), ni)
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
 
@@ -94,6 +94,7 @@ func TestConnectionString(t *testing.T) {
 }
 
 func TestConnectionArgsForDump(t *testing.T) {
+	drv := testPostgresDriver(t)
 	cases := []struct {
 		input    string
 		expected []string
@@ -109,9 +110,10 @@ func TestConnectionArgsForDump(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			u, err := url.Parse(c.input)
+			drv.databaseURL = u
 			require.NoError(t, err)
 
-			actual := connectionArgsForDump(u)
+			actual := drv.connectionArgsForDump()
 			require.Equal(t, c.expected, actual)
 		})
 	}


### PR DESCRIPTION
use DATABASE_DSN and DBMATE_DRIVER
The format of DATABASE_DSN is defined under connection string here: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

The DATABASE_URL is problematic because it is parsed to a URL in Go. This requires encoding the password for the URL which does not necessarily get decoded properly.

It is simpler to not alter the parameters to fit them into a url: that is what DATABASE_DSN does. Currently it will fail if a configuration parameter has a space. However, spaces are normally not used for any of the parameters. And that limitation can be fixed by taking on a DSN parser dependency.

## Testing

Unit tests for DSN manipulation.
Manual tests were done to see that DATABASE_DSN works with `dbmate status`. I am using it for other commands now as well.