### PR TITLE
Use system variables in migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       MYSQL_TEST_URL: mysql://root:root@mysql/dbmate_test
       POSTGRES_TEST_URL: postgres://postgres:postgres@postgres/dbmate_test?sslmode=disable
       SQLITE_TEST_URL: sqlite3:/tmp/dbmate_test.sqlite3
+      YABBA_DABBA_DOO: Yabba dabba doo!
 
   dbmate:
     build:

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -237,7 +237,7 @@ func TestWaitBeforeVerbose(t *testing.T) {
 		`Applying: 20151129054053_test_migration.sql
 Rows affected: 1
 Applying: 20200227231541_test_posts.sql
-Rows affected: 0`)
+Rows affected: 1`)
 	require.Contains(t, output,
 		`Rolling back: 20200227231541_test_posts.sql
 Rows affected: 0`)
@@ -315,6 +315,11 @@ func TestUp(t *testing.T) {
 			err = sqlDB.QueryRow("select count(*) from users").Scan(&count)
 			require.NoError(t, err)
 			require.Equal(t, 1, count)
+
+			var fromEnvVar string
+			err = sqlDB.QueryRow("select name from posts where id=1").Scan(&fromEnvVar)
+			require.NoError(t, err)
+			require.Equal(t, "Yabba dabba doo!", fromEnvVar)
 		})
 	}
 }

--- a/testdata/db/migrations/20200227231541_test_posts.sql
+++ b/testdata/db/migrations/20200227231541_test_posts.sql
@@ -1,8 +1,9 @@
--- migrate:up
+-- migrate:up env-var:YABBA_DABBA_DOO
 create table posts (
   id integer,
   name varchar(255)
 );
+insert into posts (id, name) values (1, '{{ .YABBA_DABBA_DOO }}');
 
 -- migrate:down
 drop table posts;


### PR DESCRIPTION
Add support to selectively enable usage of env vars within migrations.
Named env vars are enabled though "env-var:VAR_NAME" entries within the up/down block headers., reusing the existing parsing logic
The name of activated env vars are then kept with migration options and passed to go templating just before executing relevant migrations.

See discussion https://github.com/amacneil/dbmate/discussions/352 and issue https://github.com/amacneil/dbmate/issues/118