### PR TITLE
Add --strict flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ The following options are available with all commands. You must use command line
 - `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
 - `--migrations-dir, -d "./db/migrations"` - where to keep the migration files. _(env: `DBMATE_MIGRATIONS_DIR`)_
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
-- `--strict` - ignore out of order pending migrations. _(env: `DBMATE_STRICT`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `DBMATE_NO_DUMP_SCHEMA`)_
+- `--strict` - apply migrations strictly in numerical order. _(env: `DBMATE_STRICT`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `DBMATE_WAIT`)_
 - `--wait-timeout 60s` - timeout for --wait flag _(env: `DBMATE_WAIT_TIMEOUT`)_
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following options are available with all commands. You must use command line
 - `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
 - `--migrations-dir, -d "./db/migrations"` - where to keep the migration files. _(env: `DBMATE_MIGRATIONS_DIR`)_
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
-- `--strict-order` - ignore out of order pending migrations. _(env: `DBMATE_STRICT_ORDER`)_
+- `--strict` - ignore out of order pending migrations. _(env: `DBMATE_STRICT`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `DBMATE_NO_DUMP_SCHEMA`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `DBMATE_WAIT`)_

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following options are available with all commands. You must use command line
 - `--env, -e "DATABASE_URL"` - specify an environment variable to read the database connection URL from.
 - `--migrations-dir, -d "./db/migrations"` - where to keep the migration files. _(env: `DBMATE_MIGRATIONS_DIR`)_
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
+- `--strict-order` - ignore out of order pending migrations. _(env: `DBMATE_STRICT_ORDER`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `DBMATE_NO_DUMP_SCHEMA`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `DBMATE_WAIT`)_

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The following options are available with all commands. You must use command line
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `DBMATE_NO_DUMP_SCHEMA`)_
-- `--strict` - apply migrations strictly in numerical order. _(env: `DBMATE_STRICT`)_
+- `--strict` - fail if migrations would be applied out of order _(env: `DBMATE_STRICT`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `DBMATE_WAIT`)_
 - `--wait-timeout 60s` - timeout for --wait flag _(env: `DBMATE_WAIT_TIMEOUT`)_
 

--- a/main.go
+++ b/main.go
@@ -102,8 +102,8 @@ func NewApp() *cli.App {
 			Usage: "Create database (if necessary) and migrate to the latest version",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "strict-order",
-					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Name:    "strict",
+					EnvVars: []string{"DBMATE_STRICT"},
 					Usage:   "ignore out of order pending migrations",
 				},
 				&cli.BoolFlag{
@@ -114,7 +114,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				db.StrictOrder = c.Bool("strict-order")
+				db.Strict = c.Bool("strict")
 				db.Verbose = c.Bool("verbose")
 				return db.CreateAndMigrate()
 			}),
@@ -138,8 +138,8 @@ func NewApp() *cli.App {
 			Usage: "Migrate to the latest version",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "strict-order",
-					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Name:    "strict",
+					EnvVars: []string{"DBMATE_STRICT"},
 					Usage:   "ignore out of order pending migrations",
 				},
 				&cli.BoolFlag{
@@ -150,7 +150,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				db.StrictOrder = c.Bool("strict-order")
+				db.Strict = c.Bool("strict")
 				db.Verbose = c.Bool("verbose")
 				return db.Migrate()
 			}),
@@ -177,8 +177,8 @@ func NewApp() *cli.App {
 			Usage: "List applied and pending migrations",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:    "strict-order",
-					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Name:    "strict",
+					EnvVars: []string{"DBMATE_STRICT"},
 					Usage:   "ignore out of order pending migrations",
 				},
 				&cli.BoolFlag{
@@ -191,7 +191,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
-				db.StrictOrder = c.Bool("strict-order")
+				db.Strict = c.Bool("strict")
 				setExitCode := c.Bool("exit-code")
 				quiet := c.Bool("quiet")
 				if quiet {

--- a/main.go
+++ b/main.go
@@ -62,11 +62,6 @@ func NewApp() *cli.App {
 			Value:   defaultDB.MigrationsTableName,
 			Usage:   "specify the database table to record migrations in",
 		},
-		&cli.BoolFlag{
-			Name:    "strict-order",
-			EnvVars: []string{"DBMATE_STRICT_ORDER"},
-			Usage:   "ignore out of order pending migrations",
-		},
 		&cli.StringFlag{
 			Name:    "schema-file",
 			Aliases: []string{"s"},
@@ -107,6 +102,11 @@ func NewApp() *cli.App {
 			Usage: "Create database (if necessary) and migrate to the latest version",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
+					Name:    "strict-order",
+					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Usage:   "ignore out of order pending migrations",
+				},
+				&cli.BoolFlag{
 					Name:    "verbose",
 					Aliases: []string{"v"},
 					EnvVars: []string{"DBMATE_VERBOSE"},
@@ -114,6 +114,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				db.StrictOrder = c.Bool("strict-order")
 				db.Verbose = c.Bool("verbose")
 				return db.CreateAndMigrate()
 			}),
@@ -137,6 +138,11 @@ func NewApp() *cli.App {
 			Usage: "Migrate to the latest version",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
+					Name:    "strict-order",
+					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Usage:   "ignore out of order pending migrations",
+				},
+				&cli.BoolFlag{
 					Name:    "verbose",
 					Aliases: []string{"v"},
 					EnvVars: []string{"DBMATE_VERBOSE"},
@@ -144,6 +150,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				db.StrictOrder = c.Bool("strict-order")
 				db.Verbose = c.Bool("verbose")
 				return db.Migrate()
 			}),
@@ -170,6 +177,11 @@ func NewApp() *cli.App {
 			Usage: "List applied and pending migrations",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
+					Name:    "strict-order",
+					EnvVars: []string{"DBMATE_STRICT_ORDER"},
+					Usage:   "ignore out of order pending migrations",
+				},
+				&cli.BoolFlag{
 					Name:  "exit-code",
 					Usage: "return 1 if there are pending migrations",
 				},
@@ -179,6 +191,7 @@ func NewApp() *cli.App {
 				},
 			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				db.StrictOrder = c.Bool("strict-order")
 				setExitCode := c.Bool("exit-code")
 				quiet := c.Bool("quiet")
 				if quiet {
@@ -238,7 +251,6 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		db.AutoDumpSchema = !c.Bool("no-dump-schema")
 		db.MigrationsDir = c.StringSlice("migrations-dir")
 		db.MigrationsTableName = c.String("migrations-table")
-		db.StrictOrder = c.Bool("strict-order")
 		db.SchemaFile = c.String("schema-file")
 		db.WaitBefore = c.Bool("wait")
 		waitTimeout := c.Duration("wait-timeout")

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func NewApp() *cli.App {
 				&cli.BoolFlag{
 					Name:    "strict",
 					EnvVars: []string{"DBMATE_STRICT"},
-					Usage:   "apply migrations strictly in numerical order",
+					Usage:   "fail if migrations would be applied out of order",
 				},
 				&cli.BoolFlag{
 					Name:    "verbose",
@@ -140,7 +140,7 @@ func NewApp() *cli.App {
 				&cli.BoolFlag{
 					Name:    "strict",
 					EnvVars: []string{"DBMATE_STRICT"},
-					Usage:   "apply migrations strictly in numerical order",
+					Usage:   "fail if migrations would be applied out of order",
 				},
 				&cli.BoolFlag{
 					Name:    "verbose",

--- a/main.go
+++ b/main.go
@@ -62,6 +62,11 @@ func NewApp() *cli.App {
 			Value:   defaultDB.MigrationsTableName,
 			Usage:   "specify the database table to record migrations in",
 		},
+		&cli.BoolFlag{
+			Name:    "strict-order",
+			EnvVars: []string{"DBMATE_STRICT_ORDER"},
+			Usage:   "ignore out of order pending migrations",
+		},
 		&cli.StringFlag{
 			Name:    "schema-file",
 			Aliases: []string{"s"},
@@ -233,6 +238,7 @@ func action(f func(*dbmate.DB, *cli.Context) error) cli.ActionFunc {
 		db.AutoDumpSchema = !c.Bool("no-dump-schema")
 		db.MigrationsDir = c.StringSlice("migrations-dir")
 		db.MigrationsTableName = c.String("migrations-table")
+		db.StrictOrder = c.Bool("strict-order")
 		db.SchemaFile = c.String("schema-file")
 		db.WaitBefore = c.Bool("wait")
 		waitTimeout := c.Duration("wait-timeout")

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func NewApp() *cli.App {
 				&cli.BoolFlag{
 					Name:    "strict",
 					EnvVars: []string{"DBMATE_STRICT"},
-					Usage:   "ignore out of order pending migrations",
+					Usage:   "apply migrations strictly in numerical order",
 				},
 				&cli.BoolFlag{
 					Name:    "verbose",
@@ -140,7 +140,7 @@ func NewApp() *cli.App {
 				&cli.BoolFlag{
 					Name:    "strict",
 					EnvVars: []string{"DBMATE_STRICT"},
-					Usage:   "ignore out of order pending migrations",
+					Usage:   "apply migrations strictly in numerical order",
 				},
 				&cli.BoolFlag{
 					Name:    "verbose",
@@ -176,11 +176,6 @@ func NewApp() *cli.App {
 			Name:  "status",
 			Usage: "List applied and pending migrations",
 			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:    "strict",
-					EnvVars: []string{"DBMATE_STRICT"},
-					Usage:   "ignore out of order pending migrations",
-				},
 				&cli.BoolFlag{
 					Name:  "exit-code",
 					Usage: "return 1 if there are pending migrations",

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -18,17 +18,16 @@ import (
 
 // Error codes
 var (
-	ErrNoMigrationFiles        = errors.New("no migration files found")
-	ErrNoPendingMigrationFiles = errors.New("no pending migration files found")
-	ErrInvalidURL              = errors.New("invalid url, have you set your --url flag or DATABASE_URL environment variable?")
-	ErrNoRollback              = errors.New("can't rollback: no migrations have been applied")
-	ErrCantConnect             = errors.New("unable to connect to database")
-	ErrUnsupportedDriver       = errors.New("unsupported driver")
-	ErrNoMigrationName         = errors.New("please specify a name for the new migration")
-	ErrMigrationAlreadyExist   = errors.New("file already exists")
-	ErrMigrationDirNotFound    = errors.New("could not find migrations directory")
-	ErrMigrationNotFound       = errors.New("can't find migration file")
-	ErrCreateDirectory         = errors.New("unable to create directory")
+	ErrNoMigrationFiles      = errors.New("no migration files found")
+	ErrInvalidURL            = errors.New("invalid url, have you set your --url flag or DATABASE_URL environment variable?")
+	ErrNoRollback            = errors.New("can't rollback: no migrations have been applied")
+	ErrCantConnect           = errors.New("unable to connect to database")
+	ErrUnsupportedDriver     = errors.New("unsupported driver")
+	ErrNoMigrationName       = errors.New("please specify a name for the new migration")
+	ErrMigrationAlreadyExist = errors.New("file already exists")
+	ErrMigrationDirNotFound  = errors.New("could not find migrations directory")
+	ErrMigrationNotFound     = errors.New("can't find migration file")
+	ErrCreateDirectory       = errors.New("unable to create directory")
 )
 
 // migrationFileRegexp pattern for valid migration files
@@ -323,7 +322,7 @@ func (db *DB) Migrate() error {
 	}
 
 	if len(pendingMigrations) == 0 {
-		return ErrNoPendingMigrationFiles
+		return nil
 	}
 
 	if db.Strict {

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -328,10 +328,8 @@ func (db *DB) Migrate() error {
 			highestAppliedMigrationVersion = migrationVersion
 		}
 
-		for _, migration := range pendingMigrations {
-			if db.Strict && migration.Version <= highestAppliedMigrationVersion {
-				return fmt.Errorf("migration `%s` is out of order with already applied migrations, the version number has to be higher than the applied migration `%s` in --strict mode", migration.Version, highestAppliedMigrationVersion)
-			}
+		if db.Strict && pendingMigrations[0].Version <= highestAppliedMigrationVersion {
+			return fmt.Errorf("migration `%s` is out of order with already applied migrations, the version number has to be higher than the applied migration `%s` in --strict mode", pendingMigrations[0].Version, highestAppliedMigrationVersion)
 		}
 	}
 

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -49,7 +49,7 @@ type DB struct {
 	MigrationsTableName string
 	// SchemaFile specifies the location for schema.sql file
 	SchemaFile string
-	// Ignore out of order pending migrations
+	// Fail if migrations would be applied out of order
 	Strict bool
 	// Verbose prints the result of each statement execution
 	Verbose bool

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -50,7 +50,7 @@ type DB struct {
 	// SchemaFile specifies the location for schema.sql file
 	SchemaFile string
 	// Ignore out of order pending migrations
-	StrictOrder bool
+	Strict bool
 	// Verbose prints the result of each statement execution
 	Verbose bool
 	// WaitBefore will wait for database to become available before running any actions
@@ -77,7 +77,7 @@ func New(databaseURL *url.URL) *DB {
 		MigrationsDir:       []string{"./db/migrations"},
 		MigrationsTableName: "schema_migrations",
 		SchemaFile:          "./db/schema.sql",
-		StrictOrder:         false,
+		Strict:              false,
 		Verbose:             false,
 		WaitBefore:          false,
 		WaitInterval:        time.Second,
@@ -451,7 +451,7 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 				migration.Applied = true
 			}
 
-			if db.StrictOrder && !migration.Applied && migration.Version < latestAppliedMigration {
+			if db.Strict && !migration.Applied && migration.Version < latestAppliedMigration {
 				continue
 			}
 

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -416,9 +416,11 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 	}
 
 	var latestAppliedMigration string
-	for migrationVersion := range appliedMigrations {
-		if migrationVersion > latestAppliedMigration {
-			latestAppliedMigration = migrationVersion
+	if db.Strict {
+		for migrationVersion := range appliedMigrations {
+			if migrationVersion > latestAppliedMigration {
+				latestAppliedMigration = migrationVersion
+			}
 		}
 	}
 

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -452,7 +452,7 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 			}
 
 			if db.Strict && !migration.Applied && migration.Version < latestAppliedMigration {
-				continue
+				return nil, fmt.Errorf("Cannot apply migration `%s` after `%s` in --strict mode. Migrations have to be in numerical order.", migration.Version, latestAppliedMigration)
 			}
 
 			migrations = append(migrations, migration)

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -454,7 +454,7 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 			}
 
 			if db.Strict && !migration.Applied && migration.Version < latestAppliedMigration {
-				return nil, fmt.Errorf("Cannot apply migration `%s` after `%s` in --strict mode. Migrations have to be in numerical order.", migration.Version, latestAppliedMigration)
+				return nil, fmt.Errorf("cannot apply migration `%s` after `%s` in --strict mode, migrations have to be in numerical order", migration.Version, latestAppliedMigration)
 			}
 
 			migrations = append(migrations, migration)

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -314,14 +314,14 @@ func (db *DB) Migrate() error {
 			return err
 		}
 
-		var latestAppliedMigration string
+		var highestAppliedMigrationVersion string
 		for migrationVersion := range appliedMigrations {
-			latestAppliedMigration = migrationVersion
+			highestAppliedMigrationVersion = migrationVersion
 		}
 
 		for _, migration := range migrations {
-			if db.Strict && !migration.Applied && migration.Version <= latestAppliedMigration {
-				return fmt.Errorf("cannot apply migration `%s` after `%s` in --strict mode, migrations have to be in numerical order", migration.Version, latestAppliedMigration)
+			if db.Strict && !migration.Applied && migration.Version <= highestAppliedMigrationVersion {
+				return fmt.Errorf("migration `%s` is out of order with already applied migrations, the version number has to be higher than the applied migration `%s` in --strict mode", migration.Version, highestAppliedMigrationVersion)
 			}
 		}
 	}

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -591,8 +591,10 @@ func TestMigrateUnrestrictedOrder(t *testing.T) {
 	u := dbutil.MustParseURL(os.Getenv("POSTGRES_TEST_URL"))
 	db := newTestDB(t, u)
 
-	db.Drop()
-	db.Create()
+	err := db.Drop()
+	require.NoError(t, err)
+	err = db.Create()
+	require.NoError(t, err)
 
 	// test to apply new migrations on empty database
 	db.FS = fstest.MapFS{
@@ -600,7 +602,7 @@ func TestMigrateUnrestrictedOrder(t *testing.T) {
 		"db/migrations/100_test_migration_b.sql": { Data: emptyMigration },
 	}
 
-	err := db.Migrate()
+	err = db.Migrate()
 	require.NoError(t, err)
 
 	// test to apply an out of order migration
@@ -622,8 +624,10 @@ func TestMigrateStrictOrder(t *testing.T) {
 	db := newTestDB(t, u)
 	db.Strict = true
 
-	db.Drop()
-	db.Create()
+	err := db.Drop()
+	require.NoError(t, err)
+	err = db.Create()
+	require.NoError(t, err)
 
 	// test to apply new migrations on empty database
 	db.FS = fstest.MapFS{
@@ -631,7 +635,7 @@ func TestMigrateStrictOrder(t *testing.T) {
 		"db/migrations/010_test_migration_b.sql": { Data: emptyMigration },
 	}
 
-	err := db.Migrate()
+	err = db.Migrate()
 	require.NoError(t, err)
 
 	// test to apply an in order migration

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -598,8 +598,8 @@ func TestMigrateUnrestrictedOrder(t *testing.T) {
 
 	// test to apply new migrations on empty database
 	db.FS = fstest.MapFS{
-		"db/migrations/001_test_migration_a.sql": { Data: emptyMigration },
-		"db/migrations/100_test_migration_b.sql": { Data: emptyMigration },
+		"db/migrations/001_test_migration_a.sql": {Data: emptyMigration},
+		"db/migrations/100_test_migration_b.sql": {Data: emptyMigration},
 	}
 
 	err = db.Migrate()
@@ -607,9 +607,9 @@ func TestMigrateUnrestrictedOrder(t *testing.T) {
 
 	// test to apply an out of order migration
 	db.FS = fstest.MapFS{
-		"db/migrations/001_test_migration_a.sql": { Data: emptyMigration },
-		"db/migrations/100_test_migration_b.sql": { Data: emptyMigration },
-		"db/migrations/010_test_migration_c.sql": { Data: emptyMigration },
+		"db/migrations/001_test_migration_a.sql": {Data: emptyMigration},
+		"db/migrations/100_test_migration_b.sql": {Data: emptyMigration},
+		"db/migrations/010_test_migration_c.sql": {Data: emptyMigration},
 	}
 
 	err = db.Migrate()
@@ -631,8 +631,8 @@ func TestMigrateStrictOrder(t *testing.T) {
 
 	// test to apply new migrations on empty database
 	db.FS = fstest.MapFS{
-		"db/migrations/001_test_migration_a.sql": { Data: emptyMigration },
-		"db/migrations/010_test_migration_b.sql": { Data: emptyMigration },
+		"db/migrations/001_test_migration_a.sql": {Data: emptyMigration},
+		"db/migrations/010_test_migration_b.sql": {Data: emptyMigration},
 	}
 
 	err = db.Migrate()
@@ -640,9 +640,9 @@ func TestMigrateStrictOrder(t *testing.T) {
 
 	// test to apply an in order migration
 	db.FS = fstest.MapFS{
-		"db/migrations/001_test_migration_a.sql": { Data: emptyMigration },
-		"db/migrations/010_test_migration_b.sql": { Data: emptyMigration },
-		"db/migrations/100_test_migration_c.sql": { Data: emptyMigration },
+		"db/migrations/001_test_migration_a.sql": {Data: emptyMigration},
+		"db/migrations/010_test_migration_b.sql": {Data: emptyMigration},
+		"db/migrations/100_test_migration_c.sql": {Data: emptyMigration},
 	}
 
 	err = db.Migrate()
@@ -650,10 +650,10 @@ func TestMigrateStrictOrder(t *testing.T) {
 
 	// test to apply an out of order migration
 	db.FS = fstest.MapFS{
-		"db/migrations/001_test_migration_a.sql": { Data: emptyMigration },
-		"db/migrations/010_test_migration_b.sql": { Data: emptyMigration },
-		"db/migrations/100_test_migration_c.sql": { Data: emptyMigration },
-		"db/migrations/050_test_migration_d.sql": { Data: emptyMigration },
+		"db/migrations/001_test_migration_a.sql": {Data: emptyMigration},
+		"db/migrations/010_test_migration_b.sql": {Data: emptyMigration},
+		"db/migrations/100_test_migration_c.sql": {Data: emptyMigration},
+		"db/migrations/050_test_migration_d.sql": {Data: emptyMigration},
 	}
 
 	err = db.Migrate()


### PR DESCRIPTION
This adds the `--strict-order` flag which ignores all out of order pending migrations. With the flag set `dbmate up` and `dbmate migrate` only apply pending migrations which succeed the latest applied migration - in other words, only pending migrations with a higher version number than the latest applied migration will be used. `dbmate --strict-order status` also only lists in order pending migrations. Rollbacks work as usual.

Refs: #159