### PR TITLE
Fix docker test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Start test dependencies
         run: |
           set -x
-          docker-compose pull --quiet
+          docker-compose pull --ignore-buildable --quiet
           docker-compose up --detach
           docker-compose run --rm dev make wait
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ wait:
 
 .PHONY: docker-all
 docker-all:
-	docker-compose pull
+	docker-compose pull --ignore-buildable
 	docker-compose build
 	docker-compose run --rm dev make all
 


### PR DESCRIPTION
With "Docker version 20.10.24, build 297e128" the command `make docker-all` throws the following message:

```
WARNING: Some service image(s) must be built from source by running:
    docker compose build dbmate
1 error occurred:
        * Error response from daemon: pull access denied for dbmate_release, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

make: *** [Makefile:61: docker-all] Error 18
```

With this fix docker does not pull the images that we build afterwards anyway.