### PR TITLE
Add wait-for-current command, which waits until the database is migrated by a third party.

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,6 +206,21 @@ func NewApp() *cli.App {
 				return db.Wait()
 			}),
 		},
+		{
+			Name:  "wait-for-current",
+			Usage: "Wait for the database schema to become current",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    "quiet",
+					Aliases: []string{"v"},
+					Usage:   "don't output any text",
+				},
+			},
+			Action: action(func(db *dbmate.DB, c *cli.Context) error {
+				quiet := c.Bool("quiet")
+				return db.WaitForCurrent(quiet)
+			}),
+		},
 	}
 
 	return app

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -570,7 +570,9 @@ func (db *DB) WaitForCurrent(quiet bool) error {
 		}
 
 		if len(missing) == 0 {
-			fmt.Fprintln(db.Log, "All migrations are applied, database is current.")
+			if !quiet {
+				fmt.Fprintln(db.Log, "All migrations are applied, database is current.")
+			}
 			return nil
 		}
 


### PR DESCRIPTION
This way, we can delay the start of an application until its expected schema is present.

---

In our setup, we use `dbmate migrate` in a Kubernetes Job to perform the schema migration whenever we deploy a new version, at the same time as updating the (multiple) Kubernetes Deployments to run the new version of the application.

We take care to keep our migrations backwards compatible for at least one release, so schema version 16 can be used by backend version 15. The schema is of course not forwards compatible: schema version 15 cannot be used by backend version 16. Because it is difficult to express a dependency between the Deployments and the migration Job, it sometimes happens that backend version 16 starts up while the schema migration for version 16 is still ongoing, meaning backend 16 runs on schema 15 and starts giving RPC errors.

In order to resolve this, I would like to have backend 16 wait until its migration job is succeeded, by polling the database until the migration is completed.

This PR adds `dbmate wait-for-current`, which waits until the database schema has at least all migrations applied to it. It does not apply any migrations itself. This way, backend 16 only truly starts when migration 16 has completed, resolving the issue.