### PR TITLE
MySQL: Add ANSI_QUOTES support to MigrationsTableExists()

### DIFF
--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -233,7 +233,7 @@ func (drv *Driver) DatabaseExists() (bool, error) {
 // MigrationsTableExists checks if the schema_migrations table exists
 func (drv *Driver) MigrationsTableExists(db *sql.DB) (bool, error) {
 	match := ""
-	err := db.QueryRow(fmt.Sprintf("SHOW TABLES LIKE \"%s\"",
+	err := db.QueryRow(fmt.Sprintf("show tables like '%s'",
 		drv.migrationsTableName)).
 		Scan(&match)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
This PR addresses #444

## Problem

Dbmate currently fails to function against MySQL instances enabled with the [ANSI_QUOTES](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes) sql_mode.

My initial investigation report [can be found here](https://github.com/amacneil/dbmate/issues/444#issuecomment-1719787799).

## Why

The ANSI_QUOTES mode does not allow double-quote characters to be used for expressing string literals. Therefore ANSI_QUOTES-enabled MySQL rejects the following query produced by Dbmate's MySQL driver:

```
SHOW TABLES LIKE "schema_migrations"
```
From: https://github.com/amacneil/dbmate/blob/6245b8c/pkg/driver/mysql/mysql.go#L236

## Fix & Thought Process

MySQL driver's [quotedMigrationsTableName()](https://github.com/amacneil/dbmate/blob/6245b8c/pkg/driver/mysql/mysql.go#L316) complies with ANSI_QUOTES. Therefore I initially attempted to replicate other command implementations over to [MigrationsTableExists()](https://github.com/amacneil/dbmate/blob/6245b8c/pkg/driver/mysql/mysql.go#L234) like so:

```diff
-       err := db.QueryRow(fmt.Sprintf("SHOW TABLES LIKE \"%s\"",
-               drv.migrationsTableName)).
-               Scan(&match)
+       err := db.QueryRow("show tables like ?", drv.quotedMigrationsTableName()).Scan(&match)
```

This would be ideal for two reasons:

* Code-base consistency
* Delegating string interpolation to the sql package

However the query produced by the above code was considered invalid by MySQL (with and without ANSI_QUOTES). It appears that the LIKE predicate is picky about how the condition is quoted. Fair enough, I went a step further and tried this code instead:

```diff
- err := db.QueryRow("show tables like ?", drv.quotedMigrationsTableName()).Scan(&match)
+ err := db.QueryRow("show tables like '?'", drv.quotedMigrationsTableName()).Scan(&match)
```

Unfortunately, this time, the sql package's string interpolation was negatively affected. It seems to not appreciate the quotes around the `?` interpolation character.

```
Error: sql: expected 0 arguments, got 1
```

At this point I understood the agony of the person who last worked on this part of the code, and why MySQL driver's `MigrationsTableExists()` has an inconsistent `fmt.Sprintf` based implementation. One code consistency I was able to pick up was lower-casing the entire query.

The final code change may appear lazy but in fact a lot of thought went into it. Cheers!