### PR TITLE
Add line/column/position details to Postgres migration/rollback query error messages

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -346,7 +346,7 @@ func (db *DB) Migrate() error {
 			// run actual migration
 			result, err := tx.Exec(parsed.Up)
 			if err != nil {
-				return err
+				return drv.QueryError(parsed.Up, err)
 			} else if db.Verbose {
 				db.printVerbose(result)
 			}
@@ -508,7 +508,7 @@ func (db *DB) Rollback() error {
 		// rollback migration
 		result, err := tx.Exec(parsed.Down)
 		if err != nil {
-			return err
+			return drv.QueryError(parsed.Down, err)
 		} else if db.Verbose {
 			db.printVerbose(result)
 		}

--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -369,6 +369,11 @@ func (drv *Driver) Ping() error {
 	return err
 }
 
+// Return a normalized version of the driver-specific error type.
+func (drv *Driver) QueryError(query string, err error) error {
+	return &dbmate.QueryError{Err: err, Query: query}
+}
+
 func (drv *Driver) quotedMigrationsTableName() string {
 	return drv.quoteIdentifier(drv.migrationsTableName)
 }

--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -313,6 +313,11 @@ func (drv *Driver) Ping() error {
 	return db.Ping()
 }
 
+// Return a normalized version of the driver-specific error type.
+func (drv *Driver) QueryError(query string, err error) error {
+	return &dbmate.QueryError{Err: err, Query: query}
+}
+
 func (drv *Driver) quotedMigrationsTableName() string {
 	return drv.quoteIdentifier(drv.migrationsTableName)
 }

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/amacneil/dbmate/v2/pkg/dbmate"
@@ -361,6 +362,19 @@ func (drv *Driver) Ping() error {
 	}
 
 	return err
+}
+
+// Return a normalized version of the driver-specific error type.
+func (drv *Driver) QueryError(query string, err error) error {
+	position := 0
+
+	if pqErr, ok := err.(*pq.Error); ok {
+		if pos, err := strconv.Atoi(pqErr.Position); err == nil {
+			position = pos
+		}
+	}
+
+	return &dbmate.QueryError{Err: err, Query: query, Position: position}
 }
 
 func (drv *Driver) quotedMigrationsTableName(db dbutil.Transaction) (string, error) {

--- a/pkg/driver/sqlite/sqlite.go
+++ b/pkg/driver/sqlite/sqlite.go
@@ -243,6 +243,11 @@ func (drv *Driver) Ping() error {
 	return db.Ping()
 }
 
+// Return a normalized version of the driver-specific error type.
+func (drv *Driver) QueryError(query string, err error) error {
+	return &dbmate.QueryError{Err: err, Query: query}
+}
+
 func (drv *Driver) quotedMigrationsTableName() string {
 	return drv.quoteIdentifier(drv.migrationsTableName)
 }


### PR DESCRIPTION
Postgres's database driver returns the character position where a syntax error occurs, so dbmate can use that information to calculate the line and column within the query that the position refers to.                         

This PR supersedes the work from PR #204, simplifying the implementation a bit by minimizing the amount of code change required, plus adding additional tests, including SQL queries with UTF-8 characters present.