### PR TITLE
fix/correctly parse crlf line endings

### DIFF
--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -758,10 +758,10 @@ func TestMigrationContents(t *testing.T) {
 						Data: []byte("-- migrate:up\r\n-- migrate:down\r\n"),
 					},
 					"db/migrations/002_win_crlf_migration_basic.sql": {
-						Data: []byte("-- migrate:up\r\ncreate table users (\r\n  id integer,\r\n  name varchar(255)\r\n);\r\n-- migrate:down\r\ndrop table users;\r\n"),
+						Data: []byte("-- migrate:up\r\ncreate table test_win_crlf_basic (\r\n  id integer,\r\n  name varchar(255)\r\n);\r\n-- migrate:down\r\ndrop table test_win_crlf_basic;\r\n"),
 					},
 					"db/migrations/003_win_crlf_migration_options.sql": {
-						Data: []byte("-- migrate:up transaction:true\r\ncreate table users (\r\n  id integer,\r\n  name varchar(255)\r\n);\r\n-- migrate:down transaction:true\r\ndrop table users;\r\n"),
+						Data: []byte("-- migrate:up transaction:true\r\ncreate table test_win_crlf_options (\r\n  id integer,\r\n  name varchar(255)\r\n);\r\n-- migrate:down transaction:true\r\ndrop table test_win_crlf_options;\r\n"),
 					},
 				}
 

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -60,12 +60,12 @@ func (m migrationOptions) Transaction() bool {
 
 var (
 	upRegExp              = regexp.MustCompile(`(?m)^--\s*migrate:up(\s*$|\s+\S+)`)
-	downRegExp            = regexp.MustCompile(`(?m)^--\s*migrate:down(\s*$|\s+\S+)$`)
+	downRegExp            = regexp.MustCompile(`(?m)^--\s*migrate:down(\s*$|\s+\S+)`)
 	emptyLineRegExp       = regexp.MustCompile(`^\s*$`)
 	commentLineRegExp     = regexp.MustCompile(`^\s*--`)
 	whitespaceRegExp      = regexp.MustCompile(`\s+`)
 	optionSeparatorRegExp = regexp.MustCompile(`:`)
-	blockDirectiveRegExp  = regexp.MustCompile(`^--\s*migrate:[up|down]]`)
+	blockDirectiveRegExp  = regexp.MustCompile(`^--\s*migrate:(up|down)`)
 )
 
 // Error codes

--- a/pkg/dbmate/migration_test.go
+++ b/pkg/dbmate/migration_test.go
@@ -198,6 +198,5 @@ DROP COLUMN status;
 			require.Equal(t, migrationOptions{"transaction": "true"}, parsed.DownOptions)
 			require.Equal(t, true, parsed.DownOptions.Transaction())
 		})
-
 	})
 }

--- a/pkg/dbmate/migration_test.go
+++ b/pkg/dbmate/migration_test.go
@@ -167,4 +167,37 @@ DROP COLUMN status;
 		_, err := parseMigrationContents(migration)
 		require.Error(t, err, "dbmate does not support statements preceding the '-- migrate:up' block")
 	})
+
+	t.Run("ensure Windows CR/LF line endings in migration files are parsed correctly", func(t *testing.T) {
+		t.Run("without migration options", func(t *testing.T) {
+			migration := "-- migrate:up\r\ncreate table users (id serial, name text);\r\n-- migrate:down\r\ndrop table users;\r\n"
+
+			parsed, err := parseMigrationContents(migration)
+			require.Nil(t, err)
+
+			require.Equal(t, "-- migrate:up\r\ncreate table users (id serial, name text);\r\n", parsed.Up)
+			require.Equal(t, migrationOptions{}, parsed.UpOptions)
+			require.Equal(t, true, parsed.UpOptions.Transaction())
+
+			require.Equal(t, "-- migrate:down\r\ndrop table users;\r\n", parsed.Down)
+			require.Equal(t, migrationOptions{}, parsed.DownOptions)
+			require.Equal(t, true, parsed.DownOptions.Transaction())
+		})
+
+		t.Run("with migration options", func(t *testing.T) {
+			migration := "-- migrate:up transaction:true\r\ncreate table users (id serial, name text);\r\n-- migrate:down transaction:true\r\ndrop table users;\r\n"
+
+			parsed, err := parseMigrationContents(migration)
+			require.Nil(t, err)
+
+			require.Equal(t, "-- migrate:up transaction:true\r\ncreate table users (id serial, name text);\r\n", parsed.Up)
+			require.Equal(t, migrationOptions{"transaction": "true"}, parsed.UpOptions)
+			require.Equal(t, true, parsed.UpOptions.Transaction())
+
+			require.Equal(t, "-- migrate:down transaction:true\r\ndrop table users;\r\n", parsed.Down)
+			require.Equal(t, migrationOptions{"transaction": "true"}, parsed.DownOptions)
+			require.Equal(t, true, parsed.DownOptions.Transaction())
+		})
+
+	})
 }


### PR DESCRIPTION
- chore: add failing tests that demonstrate the issue
- fix: correct migration parsing regexps

Fixes #213.