### PR TITLE
Make appending to FLAGS possible when invoking make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OUTPUT ?= dbmate
 GOOS := $(shell go env GOOS)
 ifeq ($(GOOS),linux)
 	# statically link binaries to support alpine linux
-	override FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json  -ldflags '-s -extldflags "-static"' $(FLAGS)
+	override FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json -ldflags '-s -extldflags "-static"' $(FLAGS)
 else
 	# strip binaries
 	override FLAGS := -tags sqlite_omit_load_extension,sqlite_json -ldflags '-s' $(FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 # enable cgo to build sqlite
 export CGO_ENABLED = 1
 
-# strip binaries
-FLAGS := -tags sqlite_omit_load_extension,sqlite_json -ldflags '-s'
-
 # default output file
 OUTPUT ?= dbmate
 
@@ -11,7 +8,10 @@ OUTPUT ?= dbmate
 GOOS := $(shell go env GOOS)
 ifeq ($(GOOS),linux)
 	# statically link binaries to support alpine linux
-	FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json  -ldflags '-s -extldflags "-static"'
+	override FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json  -ldflags '-s -extldflags "-static"' $(FLAGS)
+else
+	# strip binaries
+	override FLAGS := -tags sqlite_omit_load_extension,sqlite_json -ldflags '-s' $(FLAGS)
 endif
 ifeq ($(GOOS),darwin)
 	export SDKROOT ?= $(shell xcrun --sdk macosx --show-sdk-path)


### PR DESCRIPTION
Sometimes, it's nice to be able to run just a subset of the test suite.  This change to the `Makefile` enables one to do this:

```sh
$ make test FLAGS='-run "^TestCasePrefix"'
```

Limited usefulness, but without the change to the `Makefile`, this isn't possible, so here's a PR.