### PR TITLE
Enable dependabot for docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env
+.idea
 *.log
 /.cache
 /db
@@ -8,5 +9,3 @@
 /vendor
 dist
 node_modules
-.vscode
-.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.detectIndentation": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # development image
-FROM golang:1.21 as dev
+FROM golang:1.21.4 as dev
 WORKDIR /src
 ENV PATH="/src/typescript/node_modules/.bin:${PATH}"
 RUN git config --global --add safe.directory /src
@@ -27,7 +27,7 @@ COPY . /src/
 RUN make build
 
 # release stage
-FROM alpine as release
+FROM alpine:3.19.0 as release
 RUN apk add --no-cache \
   mariadb-client \
   mariadb-connector-c \


### PR DESCRIPTION
Pin Go and Alpine container image versions, and enable Dependabot for docker images.

This means we will get notified of new Go releases which typically include security fixes.

Also unrelated:
- Commit eslint setting that keeps updating itself
- Revert adding `.vscode` to `.gitignore` from https://github.com/amacneil/dbmate/pull/432