### PR TITLE
Clickhouse - Allow schema management for multiple databases within the same cluster

### DIFF
--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -185,7 +185,12 @@ func (drv *Driver) schemaDump(db *sql.DB, buf *bytes.Buffer, databaseName string
 	buf.WriteString("\n--\n-- Database schema\n--\n\n")
 	buf.WriteString(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s%s;\n\n", drv.quoteIdentifier(databaseName), drv.onClusterClause()))
 
-	schemas := drv.parseSchemas(drv.clusterParameters.Schemas)
+	var schemas string
+	if drv.clusterParameters.Schemas != "" {
+		schemas = drv.parseSchemas(drv.clusterParameters.Schemas)
+	} else {
+		schemas = fmt.Sprintf("'%s'", databaseName)
+	}
 	query := fmt.Sprintf("SELECT database||'.'||name FROM system.tables WHERE NOT is_temporary AND database IN (%s);", schemas)
 	tables, err := dbutil.QueryColumn(db, query)
 	if err != nil {

--- a/pkg/driver/clickhouse/cluster_parameters.go
+++ b/pkg/driver/clickhouse/cluster_parameters.go
@@ -80,9 +80,6 @@ func extractReplicaMacro(u *url.URL) string {
 func extractSchemas(u *url.URL) string {
 	v := u.Query()
 	schemas := v.Get(SchemasQueryParam)
-	if schemas == "" {
-		schemas = "default"
-	}
 	return schemas
 }
 

--- a/pkg/driver/clickhouse/cluster_parameters.go
+++ b/pkg/driver/clickhouse/cluster_parameters.go
@@ -10,6 +10,7 @@ const (
 	ZooPathQueryParam      = "zoo_path"
 	ClusterMacroQueryParam = "cluster_macro"
 	ReplicaMacroQueryParam = "replica_macro"
+	SchemasQueryParam      = "schemas"
 )
 
 type ClusterParameters struct {
@@ -17,6 +18,7 @@ type ClusterParameters struct {
 	ZooPath      string
 	ClusterMacro string
 	ReplicaMacro string
+	Schemas      string
 }
 
 func ClearClusterParametersFromURL(u *url.URL) *url.URL {
@@ -24,6 +26,7 @@ func ClearClusterParametersFromURL(u *url.URL) *url.URL {
 	q.Del(OnClusterQueryParam)
 	q.Del(ClusterMacroQueryParam)
 	q.Del(ReplicaMacroQueryParam)
+	q.Del(SchemasQueryParam)
 	q.Del(ZooPathQueryParam)
 	u.RawQuery = q.Encode()
 
@@ -34,6 +37,7 @@ func ExtractClusterParametersFromURL(u *url.URL) *ClusterParameters {
 	onCluster := extractOnCluster(u)
 	clusterMacro := extractClusterMacro(u)
 	replicaMacro := extractReplicaMacro(u)
+	schemas := extractSchemas(u)
 	zookeeperPath := extractZookeeperPath(u)
 
 	r := &ClusterParameters{
@@ -41,6 +45,7 @@ func ExtractClusterParametersFromURL(u *url.URL) *ClusterParameters {
 		ZooPath:      zookeeperPath,
 		ClusterMacro: clusterMacro,
 		ReplicaMacro: replicaMacro,
+		Schemas:      schemas,
 	}
 
 	return r
@@ -70,6 +75,15 @@ func extractReplicaMacro(u *url.URL) string {
 		replicaMacro = "{replica}"
 	}
 	return replicaMacro
+}
+
+func extractSchemas(u *url.URL) string {
+	v := u.Query()
+	schemas := v.Get(SchemasQueryParam)
+	if schemas == "" {
+		schemas = "default"
+	}
+	return schemas
 }
 
 func extractZookeeperPath(u *url.URL) string {


### PR DESCRIPTION
This PR refers to the idea proposed in #514.
This is a quick implementation, testing is missing, implementation can be cleaner.
Looking to get some feedback before investing more time.

Does this feature seem reasonable? How should it be different?

To use this feature:
.env
```
DATABASE_URL="clickhouse://username:password@hostname:port/database_name?schemas=bronze,silver,gold"
```
On the terminal:
```
go build
./dbmate --env-file ./.env --env DATABASE_URL dump
```