### PR TITLE
Enable timeout flag in `make fix`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint:
 
 .PHONY: fix
 fix:
-	golangci-lint run --fix
+	golangci-lint run --fix --timeout 5m
 
 .PHONY: wait
 wait:


### PR DESCRIPTION
This PR aims for solving this [issue](https://github.com/amacneil/dbmate/issues/539).
After launching `make docker-all` in local environment, the execution of tests, as explained in README, is satisfactorily. Sharing snippet below:

```sh
WARN[0000] /workspaces/dbmate/docker-compose.yml: `version` is obsolete 
[+] Creating 7/0
 ✔ Container dbmate-clickhouse-1             Running                                                                                             0.0s 
 ✔ Container dbmate-bigquery-1               Running                                                                                             0.0s 
 ✔ Container dbmate-mysql-1                  Running                                                                                             0.0s 
 ✔ Container dbmate-zookeeper-1              Running                                                                                             0.0s 
 ✔ Container dbmate-postgres-1               Running                                                                                             0.0s 
 ✔ Container dbmate-clickhouse-cluster-01-1  Running                                                                                             0.0s 
 ✔ Container dbmate-clickhouse-cluster-02-1  Running                                                                                             0.0s 
golangci-lint run --fix --timeout 5m
rm -rf dist
go build -o dist/dbmate -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json -ldflags '-s -extldflags "-static"'  .
dist/dbmate -e CLICKHOUSE_TEST_URL wait
dist/dbmate -e MYSQL_TEST_URL wait
dist/dbmate -e POSTGRES_TEST_URL wait
go test -p 1 -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json -ldflags '-s -extldflags "-static"'  ./...
ok      github.com/amacneil/dbmate/v2   0.013s
ok      github.com/amacneil/dbmate/v2/pkg/dbmate        52.774s
ok      github.com/amacneil/dbmate/v2/pkg/dbutil        0.003s
ok      github.com/amacneil/dbmate/v2/pkg/driver/bigquery       2.810s
ok      github.com/amacneil/dbmate/v2/pkg/driver/clickhouse     10.232s
ok      github.com/amacneil/dbmate/v2/pkg/driver/mysql  4.892s
ok      github.com/amacneil/dbmate/v2/pkg/driver/postgres       47.109s
ok      github.com/amacneil/dbmate/v2/pkg/driver/sqlite 0.648s
```