### PR TITLE
CI: Run tests on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           - os: windows
             image: windows-latest
             arch: amd64
-            setup: winget install -e --id SQLite.SQLite
+            setup: choco install sqlite
             env: {}
 
     name: Build (${{ matrix.os }}/${{ matrix.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           OUTPUT: dbmate-${{ matrix.os }}-${{ matrix.arch }}
 
       - run: make test
+        if: ${{ matrix.arch == 'amd64' }}
         env:
           GOARCH: ${{ matrix.arch }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - os: windows
             image: windows-latest
             arch: amd64
+            setup: winget install -e --id SQLite.SQLite
             env: {}
 
     name: Build (${{ matrix.os }}/${{ matrix.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
           GOARCH: ${{ matrix.arch }}
           OUTPUT: dbmate-${{ matrix.os }}-${{ matrix.arch }}
 
+      - run: make test
+        env:
+          GOARCH: ${{ matrix.arch }}
+
       - run: dist/dbmate-${{ matrix.os }}-${{ matrix.arch }} --help
         if: ${{ matrix.arch == 'amd64' }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .idea
 *.log
+*.sqlite3
 /.cache
 /db
 /dbmate

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ls:
 
 .PHONY: test
 test:
-	go test -p 1 $(FLAGS) ./...
+	go test -v -p 1 $(FLAGS) ./...
 
 .PHONY: lint
 lint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       CLICKHOUSE_CLUSTER_02_TEST_URL: clickhouse://ch-cluster-02:9000/dbmate_test
       MYSQL_TEST_URL: mysql://root:root@mysql/dbmate_test
       POSTGRES_TEST_URL: postgres://postgres:postgres@postgres/dbmate_test?sslmode=disable
-      SQLITE_TEST_URL: sqlite3:/tmp/dbmate_test.sqlite3
       BIGQUERY_TEST_URL: bigquery://test/us-east5/dbmate_test?disable_auth=true&endpoint=http%3A%2F%2Fbigquery%3A9050
 
   dbmate:

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -205,7 +205,7 @@ func TestLoadSchema(t *testing.T) {
 	// load schema should return error
 	err = db.LoadSchema()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Regexp(t, "(no such file or directory|system cannot find the path specified)", err.Error())
 
 	// create schema file
 	err = db.DumpSchema()

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -99,7 +99,7 @@ func TestWait(t *testing.T) {
 
 		err := db.Wait()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "unable to connect to database: unable to open database file: no such file or directory")
+		require.Contains(t, err.Error(), "unable to connect to database: unable to open database file:")
 	})
 }
 
@@ -249,7 +249,7 @@ func checkWaitCalled(t *testing.T, db *dbmate.DB, command func() error) {
 
 	err := command()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unable to connect to database: unable to open database file: no such file or directory")
+	require.Contains(t, err.Error(), "unable to connect to database: unable to open database file:")
 
 	db.DatabaseURL = oldDatabaseURL
 }

--- a/pkg/driver/bigquery/bigquery_test.go
+++ b/pkg/driver/bigquery/bigquery_test.go
@@ -14,7 +14,12 @@ import (
 )
 
 func testBigQueryDriver(t *testing.T) *Driver {
-	u := dbutil.MustParseURL(os.Getenv("BIGQUERY_TEST_URL"))
+	url := os.Getenv("BIGQUERY_TEST_URL")
+	if url == "" {
+		t.Skip("no BIGQUERY_TEST_URL provided")
+	}
+
+	u := dbutil.MustParseURL(url)
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
 
@@ -22,9 +27,9 @@ func testBigQueryDriver(t *testing.T) *Driver {
 }
 
 func testGoogleBigQueryDriver(t *testing.T) *Driver {
-	testURL, ok := os.LookupEnv("GOOGLE_BIGQUERY_TEST_URL")
-	if !ok {
-		t.Skip("skipping test, no GOOGLE_BIGQUERY_TEST_URL provided")
+	testURL := os.Getenv("GOOGLE_BIGQUERY_TEST_URL")
+	if testURL == "" {
+		t.Skip("no GOOGLE_BIGQUERY_TEST_URL provided")
 	}
 	u := dbutil.MustParseURL(testURL)
 

--- a/pkg/driver/clickhouse/clickhouse_cluster_test.go
+++ b/pkg/driver/clickhouse/clickhouse_cluster_test.go
@@ -13,12 +13,22 @@ import (
 )
 
 func testClickHouseDriverCluster01(t *testing.T) *Driver {
-	u := fmt.Sprintf("%s?on_cluster", os.Getenv("CLICKHOUSE_CLUSTER_01_TEST_URL"))
+	url := os.Getenv("CLICKHOUSE_CLUSTER_01_TEST_URL")
+	if url == "" {
+		t.Skip("no CLICKHOUSE_CLUSTER_01_TEST_URL provided")
+	}
+
+	u := fmt.Sprintf("%s?on_cluster", url)
 	return testClickHouseDriverURL(t, u)
 }
 
 func testClickHouseDriverCluster02(t *testing.T) *Driver {
-	u := fmt.Sprintf("%s?on_cluster", os.Getenv("CLICKHOUSE_CLUSTER_02_TEST_URL"))
+	url := os.Getenv("CLICKHOUSE_CLUSTER_02_TEST_URL")
+	if url == "" {
+		t.Skip("no CLICKHOUSE_CLUSTER_02_TEST_URL provided")
+	}
+
+	u := fmt.Sprintf("%s?on_cluster", url)
 	return testClickHouseDriverURL(t, u)
 }
 
@@ -37,6 +47,10 @@ func assertDatabaseExists(t *testing.T, drv *Driver, shouldExist bool) {
 
 // Makes sure driver creatinon is atomic
 func TestDriverCreationSanity(t *testing.T) {
+	if os.Getenv("CLICKHOUSE_CLUSTER_01_TEST_URL") == "" {
+		t.Skip("no CLICKHOUSE_CLUSTER_01_TEST_URL provided")
+	}
+
 	url := fmt.Sprintf("%s?on_cluster", os.Getenv("CLICKHOUSE_CLUSTER_01_TEST_URL"))
 	u := dbutil.MustParseURL(url)
 	dbm := dbmate.New(u)

--- a/pkg/driver/clickhouse/clickhouse_testutils_test.go
+++ b/pkg/driver/clickhouse/clickhouse_testutils_test.go
@@ -20,7 +20,12 @@ func testClickHouseDriverURL(t *testing.T, url string) *Driver {
 }
 
 func testClickHouseDriver(t *testing.T) *Driver {
-	return testClickHouseDriverURL(t, os.Getenv("CLICKHOUSE_TEST_URL"))
+	url := os.Getenv("CLICKHOUSE_TEST_URL")
+	if url == "" {
+		t.Skip("no CLICKHOUSE_TEST_URL provided")
+	}
+
+	return testClickHouseDriverURL(t, url)
 }
 
 func prepTestClickHouseDB(t *testing.T, drv *Driver) *sql.DB {

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -13,7 +13,12 @@ import (
 )
 
 func testMySQLDriver(t *testing.T) *Driver {
-	u := dbutil.MustParseURL(os.Getenv("MYSQL_TEST_URL"))
+	url := os.Getenv("MYSQL_TEST_URL")
+	if url == "" {
+		t.Skip("no MYSQL_TEST_URL provided")
+	}
+
+	u := dbutil.MustParseURL(url)
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
 

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -15,7 +15,12 @@ import (
 )
 
 func testPostgresDriver(t *testing.T) *Driver {
-	u := dbutil.MustParseURL(os.Getenv("POSTGRES_TEST_URL"))
+	url := os.Getenv("POSTGRES_TEST_URL")
+	if url == "" {
+		t.Skip("no POSTGRES_TEST_URL provided")
+	}
+
+	u := dbutil.MustParseURL(url)
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
 
@@ -23,10 +28,11 @@ func testPostgresDriver(t *testing.T) *Driver {
 }
 
 func testRedshiftDriver(t *testing.T) *Driver {
-	url, ok := os.LookupEnv("REDSHIFT_TEST_URL")
-	if !ok {
-		t.Skip("skipping test, no REDSHIFT_TEST_URL provided")
+	url := os.Getenv("REDSHIFT_TEST_URL")
+	if url == "" {
+		t.Skip("no REDSHIFT_TEST_URL provided")
 	}
+
 	u := dbutil.MustParseURL(url)
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
@@ -399,10 +405,6 @@ func TestPostgresCreateMigrationsTable(t *testing.T) {
 }
 
 func TestRedshiftCreateMigrationsTable(t *testing.T) {
-	if _, ok := os.LookupEnv("REDSHIFT_TEST_URL"); !ok {
-		t.Skip("skipping test, no REDSHIFT_TEST_URL provided")
-	}
-
 	t.Run("default schema", func(t *testing.T) {
 		drv := testRedshiftDriver(t)
 		db := prepRedshiftTestDB(t, drv)

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -385,7 +385,8 @@ func TestSQLitePing(t *testing.T) {
 
 	// ping database should fail
 	err = drv.Ping()
-	require.EqualError(t, err, "unable to open database file: is a directory")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to open database file")
 }
 
 func TestSQLiteQuotedMigrationsTableName(t *testing.T) {

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func testSQLiteDriver(t *testing.T) *Driver {
-	u := dbutil.MustParseURL(os.Getenv("SQLITE_TEST_URL"))
+	u := dbutil.MustParseURL("sqlite:dbmate_test.sqlite3")
 	drv, err := dbmate.New(u).Driver()
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Run unit tests on all platforms to discover/prevent issues like https://github.com/amacneil/dbmate/issues/536
- Change dbmate package unit tests to use sqlite instead of postgres (i.e. no external dependency, although sqlite binary is currently still required due to `dbmate dump` tests)
- Integration tests can be run by passing the appropriate env vars such as `POSTGRES_TEST_URL`. If URLs are not provided they will be skipped.
- In CI we only run integration tests in the linux docker job.