### PR TITLE
Revert "fix: embedded fs on windows (#537)"

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -361,11 +360,7 @@ func (db *DB) Migrate() error {
 	}
 
 	if len(pendingMigrations) > 0 && db.Strict && pendingMigrations[0].Version <= highestAppliedMigrationVersion {
-		return fmt.Errorf(
-			"migration `%s` is out of order with already applied migrations, the version number has to be higher than the applied migration `%s` in --strict mode",
-			pendingMigrations[0].Version,
-			highestAppliedMigrationVersion,
-		)
+		return fmt.Errorf("migration `%s` is out of order with already applied migrations, the version number has to be higher than the applied migration `%s` in --strict mode", pendingMigrations[0].Version, highestAppliedMigrationVersion)
 	}
 
 	sqlDB, err := db.openDatabaseForMigration(drv)
@@ -428,7 +423,7 @@ func (db *DB) printVerbose(result sql.Result) {
 }
 
 func (db *DB) readMigrationsDir(dir string) ([]fs.DirEntry, error) {
-	path := path.Clean(dir)
+	path := filepath.Clean(dir)
 
 	// We use nil instead of os.DirFS() because DirFS cannot support both relative and absolute
 	// directory paths - it must be anchored at either "." or "/", which we do not know in advance.
@@ -488,7 +483,7 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 			migration := Migration{
 				Applied:  false,
 				FileName: matches[0],
-				FilePath: path.Join(dir, matches[0]),
+				FilePath: filepath.Join(dir, matches[0]),
 				FS:       db.FS,
 				Version:  matches[1],
 			}
@@ -500,11 +495,9 @@ func (db *DB) FindMigrations() ([]Migration, error) {
 		}
 	}
 
-	sort.Slice(
-		migrations, func(i, j int) bool {
-			return migrations[i].FileName < migrations[j].FileName
-		},
-	)
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].FileName < migrations[j].FileName
+	})
 
 	return migrations, nil
 }


### PR DESCRIPTION
I am not going to merge this PR. The point of it is to prove that the issue described in https://github.com/amacneil/dbmate/issues/536 and fixed by https://github.com/amacneil/dbmate/pull/537 is reproducible now that we run CI tests on Windows.

Reverts commit 716b623d095a384189f37e7dccc4f230e2786e89.