### PR TITLE
Spanner Postgres interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,32 @@ bigquery://host:port/projectid/location/dataset?disable_auth=true
 
 `disable_auth` (optional) - Pass `true` to skip Authentication, use only for testing and connecting to emulator.
 
+#### Spanner (PostgreSQL Interface)
+
+Spanner support is currently limited to databases using the [PostgreSQL Dialect](https://cloud.google.com/spanner/docs/postgresql-interface), which must be chosen during database creation. For future Spanner with GoogleSQL support, see [this discussion](https://github.com/amacneil/dbmate/discussions/369).
+
+Spanner with the Postgres interface requires that the [PGAdapter](https://cloud.google.com/spanner/docs/pgadapter) is running. Use the following format for `DATABASE_URL`, with the host and port set to where the PGAdapter is running:
+
+```shell
+DATABASE_URL="spanner-postgres://127.0.0.1:5432/database_name?sslmode=disable"
+```
+
+Note that specifying a username and password is not necessary, as authentication is handled by the PGAdapter (they will be ignored by the PGAdapter if specified).
+
+Other options of the [postgres driver](#postgresql) are supported.
+
+Spanner also doesn't allow DDL to be executed inside explicit transactions. You must therefore specify `transaction:false` on migrations that include DDL:
+
+```sql
+-- migrate:up transaction:false
+CREATE TABLE ...
+
+-- migrate:down transaction:false
+DROP TABLE ...
+```
+
+Schema dumps are not currently supported, as `pg_dump` uses functions that are not provided by Spanner.
+
 ### Creating Migrations
 
 To create a new migration, run `dbmate new create_users_table`. You can name the migration anything you like. This will create a file `db/migrations/20151127184807_create_users_table.sql` in the current directory:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - clickhouse-cluster-01
       - clickhouse-cluster-02
       - bigquery
+      - spanner-emulator
     environment:
       CLICKHOUSE_TEST_URL: clickhouse://clickhouse:9000/dbmate_test
       CLICKHOUSE_CLUSTER_01_TEST_URL: clickhouse://ch-cluster-01:9000/dbmate_test
@@ -20,6 +21,7 @@ services:
       MYSQL_TEST_URL: mysql://root:root@mysql/dbmate_test
       POSTGRES_TEST_URL: postgres://postgres:postgres@postgres/dbmate_test?sslmode=disable
       BIGQUERY_TEST_URL: bigquery://test/us-east5/dbmate_test?disable_auth=true&endpoint=http%3A%2F%2Fbigquery%3A9050
+      SPANNER_POSTGRES_TEST_URL: spanner-postgres://spanner-emulator/dbmate_test?sslmode=disable
 
   dbmate:
     build:
@@ -69,3 +71,6 @@ services:
     image: ghcr.io/goccy/bigquery-emulator:0.4.4
     command: |
       --project=test --dataset=dbmate_test
+
+  spanner-emulator:
+    image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator


### PR DESCRIPTION
Adds support for the [GCP Spanner Postgres Interface](https://cloud.google.com/spanner/docs/postgresql-interface), which only requires a slight modification to the postgres driver.

This will not work with a GoogleSQL-flavored Spanner database; support for that will require a dedicated driver.

The new functionality is accessed with a custom `spanner-postgres://` scheme. This is rather un-standard and something I just made up, so the exact scheme is open for debate. We shouldn't use just `spanner://`, since that may cause confusion down the line when a driver for Spanner with the GoogleSQL dialect is added.

Related discussion: https://github.com/amacneil/dbmate/discussions/369