### PR TITLE
add go install as installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ scoop install dbmate
 
 **GO Install**
 
-Remember to add `~/go/bin` into your `$PATH` if you decide to install dbmate this way.
+Remember to add `"$(go env GOPATH)/bin"` into your `$PATH` if you decide to install dbmate this way.
 
 ```sh
 go install github.com/amacneil/dbmate/v2

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Install using [Scoop](https://scoop.sh)
 $ scoop install dbmate
 ```
 
+**GO Install**
+
+Remember to add `~/go/bin` into your `$PATH` if you decide to install dbmate this way.
+
+```sh
+go install github.com/amacneil/dbmate/v2
+```
+
 **Docker**
 
 Docker images are published to GitHub Container Registry ([`ghcr.io/amacneil/dbmate`](https://ghcr.io/amacneil/dbmate)).


### PR DESCRIPTION
use go install results in a functional dbmate installation, as far as my tests goes.

please add this as installation option in the documentation.