### PR TITLE
Enable FTS5 in SQLite migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ OUTPUT ?= dbmate
 GOOS := $(shell go env GOOS)
 ifeq ($(GOOS),linux)
 	# statically link binaries to support alpine linux
-	override FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_json -ldflags '-s -extldflags "-static"' $(FLAGS)
+	override FLAGS := -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_fts5,sqlite_json -ldflags '-s -extldflags "-static"' $(FLAGS)
 else
 	# strip binaries
-	override FLAGS := -tags sqlite_omit_load_extension,sqlite_json -ldflags '-s' $(FLAGS)
+	override FLAGS := -tags sqlite_omit_load_extension,sqlite_fts5,sqlite_json -ldflags '-s' $(FLAGS)
 endif
 ifeq ($(GOOS),darwin)
 	export SDKROOT ?= $(shell xcrun --sdk macosx --show-sdk-path)

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -406,17 +406,11 @@ func TestSQLiteQuotedMigrationsTableName(t *testing.T) {
 	})
 }
 
-func TestSQLiteFTS5MigrationsTable(t *testing.T) {
-	drv := testSQLiteDriver(t)
-	drv.migrationsTableName = "test_migrations"
-
-	// prepare database
+func TestSQLiteFTS5Available(t *testing.T) {
 	db := prepTestSQLiteDB(t)
 	defer dbutil.MustClose(db)
-	err := drv.CreateMigrationsTable(db)
-	require.NoError(t, err)
 
-	// this only passes if the FTS5 module is staticall compiled in to the SQLite driver
-	_, err = db.Exec("CREATE VIRTUAL TABLE a USING fts5(b, c)")
+	// this only passes if the FTS5 module is statically compiled in to the SQLite driver
+	_, err := db.Exec("CREATE VIRTUAL TABLE a USING fts5(b, c)")
 	require.NoError(t, err)
 }

--- a/pkg/driver/sqlite/sqlite_test.go
+++ b/pkg/driver/sqlite/sqlite_test.go
@@ -405,3 +405,18 @@ func TestSQLiteQuotedMigrationsTableName(t *testing.T) {
 		require.Equal(t, `"fooMigrations"`, name)
 	})
 }
+
+func TestSQLiteFTS5MigrationsTable(t *testing.T) {
+	drv := testSQLiteDriver(t)
+	drv.migrationsTableName = "test_migrations"
+
+	// prepare database
+	db := prepTestSQLiteDB(t)
+	defer dbutil.MustClose(db)
+	err := drv.CreateMigrationsTable(db)
+	require.NoError(t, err)
+
+	// this only passes if the FTS5 module is staticall compiled in to the SQLite driver
+	_, err = db.Exec("CREATE VIRTUAL TABLE a USING fts5(b, c)")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This statically compiles in the FTS5 module, allowing dbmate to handle migrations that use the full-text search features of SQLite.

## History

Issue #237 raised the question of handling migrations that included FTS5 tables. It was later converted to a discussion (#357).

## Solution

It is possible to enable the feature in the statically-compiled SQLite that ships with dbmate via a feature flag. Adding the `sqlite_fts5` flag to the `Makefile` embeds this feature statically.

## Testing

An additional test was added with a `CREATE VIRTUAL TABLE` statement that leverages the FTS5 module. This test fails when dbmate is compiled _without_ the feature flag. After adding the flag, this test passes.

`make test` and `make docker-all` pass.

Confirmed that it works in practice locally on Ubuntu 22.04.  

## Additional info

For information about the extension:
https://www.sqlite.org/fts5.html

For the feature flag for mattn/go-sqlite3:
https://github.com/mattn/go-sqlite3/?tab=readme-ov-file#feature--extension-list