### PR TITLE
feat: support multiple queries for clickhouse using up/down-sections

### DIFF
--- a/pkg/dbmate/version.go
+++ b/pkg/dbmate/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "2.21.0"
+const Version = "2.22.0"


### PR DESCRIPTION
Currently, ClickHouse does not support executing multiple queries. However with these changes, it becomes possible.
We just put each separate up- or down-query in sections, but sections are optional.