### PR TITLE
Add 'UseMigrationLock' flag to aquire exlusive lock while performing migrations for Postgres

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,10 @@ func NewApp() *cli.App {
 			Usage:   "timeout for --wait flag",
 			Value:   defaultDB.WaitTimeout,
 		},
+		&cli.BoolFlag{
+			Name:  "migration-lock",
+			Usage: "use a lock during the migration so other dbmate instances can not run migrations at the same time",
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -127,6 +131,7 @@ func NewApp() *cli.App {
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				db.Strict = c.Bool("strict")
 				db.Verbose = c.Bool("verbose")
+				db.UseMigrationLock = c.Bool("migration-lock")
 				return db.CreateAndMigrate()
 			}),
 		},
@@ -163,6 +168,7 @@ func NewApp() *cli.App {
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				db.Strict = c.Bool("strict")
 				db.Verbose = c.Bool("verbose")
+				db.UseMigrationLock = c.Bool("migration-lock")
 				return db.Migrate()
 			}),
 		},

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -60,6 +60,8 @@ type DB struct {
 	WaitInterval time.Duration
 	// WaitTimeout specifies maximum time for connection attempts
 	WaitTimeout time.Duration
+	// UseMigrationLock uses an exclusive lock while performing migrations
+	UseMigrationLock bool
 }
 
 // StatusResult represents an available migration status
@@ -83,6 +85,7 @@ func New(databaseURL *url.URL) *DB {
 		WaitBefore:          false,
 		WaitInterval:        time.Second,
 		WaitTimeout:         60 * time.Second,
+		UseMigrationLock:    false,
 	}
 }
 
@@ -153,10 +156,34 @@ func (db *DB) Wait() error {
 }
 
 // CreateAndMigrate creates the database (if necessary) and runs migrations
-func (db *DB) CreateAndMigrate() error {
+func (db *DB) CreateAndMigrate() (returnErr error) {
 	drv, err := db.Driver()
 	if err != nil {
 		return err
+	}
+
+	// try and acquire a lock for the duration of the migration.
+	// this is to prevent multiple instances performing the same migration in parallel.
+	if db.UseMigrationLock {
+		drvLock, ok := drv.(DriverMigrationLock)
+		if !ok {
+			return fmt.Errorf("driver does not support the use of a migration lock")
+		}
+
+		if err := drvLock.Lock(); err != nil {
+			return err
+		}
+
+		defer func() {
+			err := drvLock.Unlock()
+			if err != nil {
+				if returnErr != nil {
+					returnErr = fmt.Errorf("failed to unlock: %v: %w", err, returnErr)
+					return
+				}
+				returnErr = fmt.Errorf("failed to unlock: %w", err)
+			}
+		}()
 	}
 
 	// create database if it does not already exist
@@ -333,10 +360,35 @@ func (db *DB) openDatabaseForMigration(drv Driver) (*sql.DB, error) {
 }
 
 // Migrate migrates database to the latest version
-func (db *DB) Migrate() error {
+func (db *DB) Migrate() (returnErr error) {
 	drv, err := db.Driver()
 	if err != nil {
 		return err
+	}
+
+	if db.UseMigrationLock {
+		drvLock, ok := drv.(DriverMigrationLock)
+		if !ok {
+			return fmt.Errorf("driver does not support the use of a migration lock")
+		}
+
+		// only try and lock if we haven't already done so, e.g called CreateAndMigrate.
+		if !drvLock.IsLocked() {
+			if err := drvLock.Lock(); err != nil {
+				return err
+			}
+
+			defer func() {
+				err := drvLock.Unlock()
+				if err != nil {
+					if returnErr != nil {
+						returnErr = fmt.Errorf("failed to unlock: %v: %w", err, returnErr)
+						return
+					}
+					returnErr = fmt.Errorf("failed to unlock: %w", err)
+				}
+			}()
+		}
 	}
 
 	migrations, err := db.FindMigrations()

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -59,6 +59,7 @@ func TestNew(t *testing.T) {
 	require.False(t, db.WaitBefore)
 	require.Equal(t, time.Second, db.WaitInterval)
 	require.Equal(t, 60*time.Second, db.WaitTimeout)
+	require.Equal(t, false, db.UseMigrationLock)
 }
 
 func TestGetDriver(t *testing.T) {

--- a/pkg/dbmate/driver.go
+++ b/pkg/dbmate/driver.go
@@ -25,6 +25,12 @@ type Driver interface {
 	QueryError(string, error) error
 }
 
+type DriverMigrationLock interface {
+	Lock() error
+	Unlock() error
+	IsLocked() bool
+}
+
 // DriverConfig holds configuration passed to driver constructors
 type DriverConfig struct {
 	DatabaseURL         *url.URL


### PR DESCRIPTION
First I'd like to thank you @amacneil for all the hard work, been using this project for years now and it's the best tool for the job.

We currently have a client who are performing migrations from within their code using the dbmate library to do so. They have multiple components that are run as their own deployment in kubernetes, meaning each component is peforming a migration. When we do new deployments of this application, each component starts up and migrations are attempted at the same time, resulting in race conditions.

We have resolved this by adding a new `DriverMigrationLock` interface, that the Postgres driver implements. It uses an postgres advisory lock within a database transaction to prevent any other dbmate instance from migrating while the lock is active.

The use of the exclusive lock is currently opt-in by using the `UseMigrationLock` field on the `DB` struct.

I feel like this might be something more people would like to have, who might be in a similar position.

I have added a few tests for the Postgres driver, I can add more, but unsure what exactly what we should test? It might be nice to have one test for the `DB` struct, if so, could you point me in the right direction?