### PR TITLE
Remove binary_parameters from pg_dump database url

### DIFF
--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -101,6 +101,7 @@ func connectionArgsForDump(conn *url.URL) []string {
 	query := u.Query()
 	schemas := strings.Split(query.Get("search_path"), ",")
 	query.Del("search_path")
+	query.Del("binary_parameters")
 	u.RawQuery = query.Encode()
 
 	out := []string{}


### PR DESCRIPTION
These are sometimes needed in the pq library, but are not supported when calling pg_dump.