### PR TITLE
Allow multiple hostnames in postgres connection url

### DIFF
--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -85,7 +85,14 @@ func connectionString(u *url.URL) string {
 	out, _ := url.Parse(u.String())
 	// force scheme back to postgres if there was another postgres-compatible scheme
 	out.Scheme = "postgres"
-	out.Host = fmt.Sprintf("%s:%s", hostname, port)
+
+	hosts := strings.Split(hostname, ",")
+	hostPorts := []string{}
+	for _, h := range hosts {
+		hostPorts = append(hostPorts, fmt.Sprintf("%s:%s", h, port))
+	}
+
+	out.Host = strings.Join(hostPorts, ",")
 	out.RawQuery = query.Encode()
 
 	return out.String()

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -123,6 +123,7 @@ func TestConnectionString(t *testing.T) {
 		// support `host` and `port` via url params
 		{"postgres://bob:secret@myhost:1234/foo?host=new&port=9999", "postgres://bob:secret@:9999/foo?host=new"},
 		{"postgres://bob:secret@myhost:1234/foo?port=9999&bar=baz", "postgres://bob:secret@myhost:9999/foo?bar=baz"},
+		{"postgres://bob:secret@myhost,myhost2/foo?port=9999&bar=baz", "postgres://bob:secret@myhost:9999,myhost2:9999/foo?bar=baz"},
 		// support unix sockets via `host` or `socket` param
 		{"postgres://bob:secret@myhost:1234/foo?host=/var/run/postgresql", "postgres://bob:secret@:1234/foo?host=%2Fvar%2Frun%2Fpostgresql"},
 		{"postgres://bob:secret@localhost/foo?socket=/var/run/postgresql", "postgres://bob:secret@:5432/foo?host=%2Fvar%2Frun%2Fpostgresql"},


### PR DESCRIPTION
This PR adds support for URL connection strings with [multiple hosts](https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-CONNSTRING-URIS), eg.

```
postgresql://host1:123,host2:456/somedb?target_session_attrs=any&application_name=myapp
```