### PR TITLE
Enable usetesting linter and simplify tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
     - whitespace
 
 linters-settings:

--- a/main_test.go
+++ b/main_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGetDatabaseUrl(t *testing.T) {
 	// set environment variables
-	require.NoError(t, os.Setenv("DATABASE_URL", "foo://example.org/one"))
-	require.NoError(t, os.Setenv("CUSTOM_URL", "foo://example.org/two"))
+	t.Setenv("DATABASE_URL", "foo://example.org/one")
+	t.Setenv("CUSTOM_URL", "foo://example.org/two")
 
 	app := NewApp()
 	flagset := flag.NewFlagSet(app.Name, flag.ContinueOnError)
@@ -85,7 +85,7 @@ func TestLoadEnvFiles(t *testing.T) {
 
 			for _, e := range env {
 				pair := strings.SplitN(e, "=", 2)
-				os.Setenv(pair[0], pair[1])
+				t.Setenv(pair[0], pair[1])
 			}
 		})
 	}
@@ -131,7 +131,7 @@ func TestLoadEnvFiles(t *testing.T) {
 		setup(t)
 
 		// we do not load values over existing values
-		os.Setenv("FIRST", "not one")
+		t.Setenv("FIRST", "not one")
 
 		err := loadEnvFiles([]string{"--env-file", "first.txt"})
 		require.NoError(t, err)

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -109,15 +109,13 @@ func TestDumpSchema(t *testing.T) {
 	db := newTestDB(t, sqliteTestURL(t))
 
 	// create custom schema file directory
-	dir, err := os.MkdirTemp("", "dbmate")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create schema.sql in subdirectory to test creating directory
 	db.SchemaFile = filepath.Join(dir, "/schema/schema.sql")
 
 	// drop database
-	err = db.Drop()
+	err := db.Drop()
 	require.NoError(t, err)
 
 	// create and migrate
@@ -143,15 +141,13 @@ func TestAutoDumpSchema(t *testing.T) {
 	db.AutoDumpSchema = true
 
 	// create custom schema file directory
-	dir, err := os.MkdirTemp("", "dbmate")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create schema.sql in subdirectory to test creating directory
 	db.SchemaFile = filepath.Join(dir, "/schema/schema.sql")
 
 	// drop database
-	err = db.Drop()
+	err := db.Drop()
 	require.NoError(t, err)
 
 	// schema.sql should not exist
@@ -187,9 +183,7 @@ func TestLoadSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// create custom schema file directory
-	dir, err := os.MkdirTemp("", "dbmate")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// create schema.sql in subdirectory to test creating directory
 	db.SchemaFile = filepath.Join(dir, "/schema/schema.sql")
@@ -556,9 +550,7 @@ func TestFindMigrationsAbsolute(t *testing.T) {
 	})
 
 	t.Run("absolute path", func(t *testing.T) {
-		dir, err := os.MkdirTemp("", "dbmate")
-		require.NoError(t, err)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		require.True(t, filepath.IsAbs(dir))
 
 		file, err := os.Create(filepath.Join(dir, "1234_example.sql"))


### PR DESCRIPTION
[`usetesting`](https://golangci-lint.run/usage/linters/#usetesting) tells that we can replace `os.Setenv` with `t.Setenv` and `os.MkdirTemp` with `t.TempDir`. As a result, this slightly simplifies tests.

```sh
$ golangci-lint run
pkg/dbmate/db_test.go:112:14: os.MkdirTemp() could be replaced by t.TempDir() in TestDumpSchema (usetesting)
        dir, err := os.MkdirTemp("", "dbmate")
                    ^
pkg/dbmate/db_test.go:146:14: os.MkdirTemp() could be replaced by t.TempDir() in TestAutoDumpSchema (usetesting)
        dir, err := os.MkdirTemp("", "dbmate")
                    ^
pkg/dbmate/db_test.go:190:14: os.MkdirTemp() could be replaced by t.TempDir() in TestLoadSchema (usetesting)
        dir, err := os.MkdirTemp("", "dbmate")
                    ^
pkg/dbmate/db_test.go:559:15: os.MkdirTemp() could be replaced by t.TempDir() in TestFindMigrationsAbsolute (usetesting)
                dir, err := os.MkdirTemp("", "dbmate")
                            ^
main_test.go:15:21: os.Setenv() could be replaced by t.Setenv() in TestGetDatabaseUrl (usetesting)
        require.NoError(t, os.Setenv("DATABASE_URL", "foo://example.org/one"))
                           ^
main_test.go:16:21: os.Setenv() could be replaced by t.Setenv() in TestGetDatabaseUrl (usetesting)
        require.NoError(t, os.Setenv("CUSTOM_URL", "foo://example.org/two"))
                           ^
main_test.go:88:5: os.Setenv() could be replaced by t.Setenv() in TestLoadEnvFiles (usetesting)
                                os.Setenv(pair[0], pair[1])
                                ^
main_test.go:134:3: os.Setenv() could be replaced by t.Setenv() in TestLoadEnvFiles (usetesting)
                os.Setenv("FIRST", "not one")
                ^
```