### PR TITLE
[CVE-2025-22871] Bump Module's Go Toolchain to 1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # development stage
-FROM golang:1.24.2 as dev
+FROM golang:1.24.3 as dev
 WORKDIR /src
 ENV PATH="/src/typescript/node_modules/.bin:${PATH}"
 RUN git config --global --add safe.directory /src

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/amacneil/dbmate/v2
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.24.3
 
 require (
 	cloud.google.com/go/bigquery v1.67.0


### PR DESCRIPTION
## [CVE-2025-22871] Bump Module's Go Toolchain to 1.24.3

Bumping to patch for a CVE in the Go std lib: https://nvd.nist.gov/vuln/detail/CVE-2025-22871

Note: Overrides (or requires) https://github.com/amacneil/dbmate/pull/647