### PR TITLE
chore: bump dbmate version to 2.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # development stage
-FROM golang:1.24.4 as dev
+FROM golang:1.24.5 as dev
 WORKDIR /src
 ENV PATH="/src/typescript/node_modules/.bin:${PATH}"
 RUN git config --global --add safe.directory /src

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/amacneil/dbmate/v2
 
 go 1.23.0
 
-toolchain go1.24.3
+toolchain go1.24.5
 
 require (
 	cloud.google.com/go/bigquery v1.67.0

--- a/pkg/dbmate/version.go
+++ b/pkg/dbmate/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "2.27.0"
+const Version = "2.28.0"


### PR DESCRIPTION
### Description

Hi! We are using dbmate in production, and it got flagged for vulnerabilities due to the latest version being packaged with Go 1.24.2.

I wanted to submit a PR to make a new release of dbmate with the CVE addressed 😄 