### PR TITLE
Pin Spanner pgadapter-emulator to v0.48.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,4 +72,4 @@ services:
       --project=test --dataset=dbmate_test
 
   spanner-emulator:
-    image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator
+    image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator:v0.48.3


### PR DESCRIPTION
A change to the [Google Cloud Spanner PGAdapter and Spanner Emulator][1] in v0.48.4 is breaking our `dbmate` test.

[1]: https://github.com/GoogleCloudPlatform/pgadapter?tab=readme-ov-file#emulator

Our tests did not pin to a particular version, resulting in our tests starting to fail with no change to dbmate.

```shell
# grep -A1 spanner-emulator: docker-compose.yml 
  spanner-emulator:
    image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator:v0.48.4

# go test -v -p 1 -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_fts5,sqlite_json -ldflags '-s -extldflags "-static"' -run TestSpannerPostgresCreateMigrationsTable ./pkg/driver/postgres # ./...
=== RUN   TestSpannerPostgresCreateMigrationsTable
=== RUN   TestSpannerPostgresCreateMigrationsTable/default_schema
    postgres_test.go:83:
                Error Trace:    /src/pkg/driver/postgres/postgres_test.go:83
                                                        /src/pkg/driver/postgres/postgres_test.go:451
                Error:          Received unexpected error:
                                pq: NOT_FOUND: io.grpc.StatusRuntimeException: NOT_FOUND: Input file third_party/spanner_pg/catalog/proto/functions.txtpb not opened successfully. - Statement: 'select option_value from information_schema.database_options where option_name='database_dialect''
                Test:           TestSpannerPostgresCreateMigrationsTable/default_schema
--- FAIL: TestSpannerPostgresCreateMigrationsTable (0.04s)
    --- FAIL: TestSpannerPostgresCreateMigrationsTable/default_schema (0.04s)
FAIL
FAIL    github.com/amacneil/dbmate/v2/pkg/driver/postgres       0.046s
FAIL
make: *** [Makefile:43: test] Error 1
```

Our tests were passing up until version v0.48.3.

```shell
# grep -A1 spanner-emulator: docker-compose.yml 
  spanner-emulator:
    image: gcr.io/cloud-spanner-pg-adapter/pgadapter-emulator:v0.48.3

# go test -v -p 1 -tags netgo,osusergo,sqlite_omit_load_extension,sqlite_fts5,sqlite_json -ldflags '-s -extldflags "-static"' -run TestSpannerPostgresCreateMigrationsTable ./pkg/driver/postgres # ./...
=== RUN   TestSpannerPostgresCreateMigrationsTable
=== RUN   TestSpannerPostgresCreateMigrationsTable/default_schema
--- PASS: TestSpannerPostgresCreateMigrationsTable (2.12s)
    --- PASS: TestSpannerPostgresCreateMigrationsTable/default_schema (2.12s)
PASS
ok      github.com/amacneil/dbmate/v2/pkg/driver/postgres       2.123s
```

As this appears to be a failure introduced in the upstream emulator, let's pin our tests to version v0.48.3 for now.
