### PR TITLE
Fix clickhouse schema dump with non-default database

### DIFF
--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -141,8 +141,8 @@ func (drv *Driver) escapeString(str string) string {
 
 // CreateDatabase creates the specified database
 func (drv *Driver) CreateDatabase() error {
-	name := drv.databaseName()
-	fmt.Fprintf(drv.log, "Creating: %s\n", name)
+	databaseName := drv.quotedDatabaseName()
+	fmt.Fprintf(drv.log, "Creating: %s\n", databaseName)
 
 	db, err := drv.openClickHouseDB()
 	if err != nil {
@@ -150,7 +150,7 @@ func (drv *Driver) CreateDatabase() error {
 	}
 	defer dbutil.MustClose(db)
 
-	q := fmt.Sprintf("CREATE DATABASE %s%s", drv.quoteIdentifier(name), drv.onClusterClause())
+	q := fmt.Sprintf("CREATE DATABASE %s%s", databaseName, drv.onClusterClause())
 
 	_, err = db.Exec(q)
 
@@ -175,9 +175,9 @@ func (drv *Driver) DropDatabase() error {
 	return err
 }
 
-func (drv *Driver) schemaDump(db *sql.DB, buf *bytes.Buffer, databaseName string) error {
+func (drv *Driver) schemaDump(db *sql.DB, buf *bytes.Buffer) error {
 	buf.WriteString("\n--\n-- Database schema\n--\n\n")
-	fmt.Fprintf(buf, "CREATE DATABASE IF NOT EXISTS %s%s;\n\n", drv.quoteIdentifier(databaseName), drv.onClusterClause())
+	fmt.Fprintf(buf, "CREATE DATABASE IF NOT EXISTS %s%s;\n\n", drv.quotedDatabaseName(), drv.onClusterClause())
 
 	tables, err := dbutil.QueryColumn(db, "show tables")
 	if err != nil {
@@ -218,7 +218,7 @@ func (drv *Driver) schemaMigrationsDump(db *sql.DB, buf *bytes.Buffer) error {
 
 	if len(migrations) > 0 {
 		buf.WriteString(
-			fmt.Sprintf("INSERT INTO %s (version) VALUES\n    (", migrationsTable) +
+			fmt.Sprintf("INSERT INTO %s.%s (version) VALUES\n    (", drv.quotedDatabaseName(), migrationsTable) +
 				strings.Join(migrations, "),\n    (") +
 				");\n")
 	}
@@ -231,7 +231,7 @@ func (drv *Driver) DumpSchema(db *sql.DB) ([]byte, error) {
 	var buf bytes.Buffer
 	var err error
 
-	err = drv.schemaDump(db, &buf, drv.databaseName())
+	err = drv.schemaDump(db, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -381,4 +381,8 @@ func (drv *Driver) QueryError(query string, err error) error {
 
 func (drv *Driver) quotedMigrationsTableName() string {
 	return drv.quoteIdentifier(drv.migrationsTableName)
+}
+
+func (drv *Driver) quotedDatabaseName() string {
+	return drv.quoteIdentifier(drv.databaseName())
 }

--- a/pkg/driver/clickhouse/clickhouse_cluster_test.go
+++ b/pkg/driver/clickhouse/clickhouse_cluster_test.go
@@ -120,7 +120,7 @@ func TestClickHouseDumpSchemaOnCluster(t *testing.T) {
 	require.Contains(t, string(schema), "--\n"+
 		"-- Dbmate schema migrations\n"+
 		"--\n\n"+
-		"INSERT INTO test_migrations (version) VALUES\n"+
+		"INSERT INTO "+drv.databaseName()+".test_migrations (version) VALUES\n"+
 		"    ('abc1'),\n"+
 		"    ('abc2');\n")
 

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -123,7 +123,7 @@ func TestClickHouseDumpSchema(t *testing.T) {
 	require.Contains(t, string(schema), "--\n"+
 		"-- Dbmate schema migrations\n"+
 		"--\n\n"+
-		"INSERT INTO test_migrations (version) VALUES\n"+
+		"INSERT INTO "+drv.databaseName()+".test_migrations (version) VALUES\n"+
 		"    ('abc1'),\n"+
 		"    ('abc2');\n")
 


### PR DESCRIPTION
This fixes the issue of using a generated `schema.sql` with ClickHouse in Docker.
The ClickHouse entrypoint runs every `.sql` file in `/docker-entrypoint-initdb.d` during server startup, but it executes them against the default database.

It works if the schema dump was created from the default database, but it fails otherwise:
```
/entrypoint.sh: running /docker-entrypoint-initdb.d/schema.sql
Received exception from server (version 25.3.6):
Code: 60. DB::Exception: Received from 127.0.0.1:9000. DB::Exception: Table default.schema_migrations does not exist. Maybe you meant my_database_name.schema_migrations?. (UNKNOWN_TABLE)
```
This fix prefixes `migrations_table_name` with `db_name.` in the generated schema, making it consistent with the table creation statements and with other drivers.