### PR TITLE
[pg] \restrict header + footer fix

### DIFF
--- a/pkg/dbutil/dbutil_test.go
+++ b/pkg/dbutil/dbutil_test.go
@@ -26,14 +26,125 @@ func TestDatabaseName(t *testing.T) {
 }
 
 func TestTrimLeadingSQLComments(t *testing.T) {
-	in := "--\n" +
-		"-- foo\n\n" +
-		"-- bar\n\n" +
-		"real stuff\n" +
-		"-- end\n"
-	out, err := dbutil.TrimLeadingSQLComments([]byte(in))
-	require.NoError(t, err)
-	require.Equal(t, "real stuff\n-- end\n", string(out))
+	t.Run("basic comments", func(t *testing.T) {
+		in := "--\n" +
+			"-- foo\n\n" +
+			"-- bar\n\n" +
+			"real stuff\n" +
+			"-- end\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "real stuff\n-- end\n", string(out))
+	})
+
+	t.Run("restrict header", func(t *testing.T) {
+		in := "\\restrict abc123\n" +
+			"--\n" +
+			"-- PostgreSQL database dump\n" +
+			"--\n\n" +
+			"CREATE TABLE users (id int);\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "CREATE TABLE users (id int);\n", string(out))
+	})
+
+	t.Run("multiple backslash commands", func(t *testing.T) {
+		in := "\\restrict key123\n" +
+			"\\set VERBOSITY terse\n" +
+			"--\n" +
+			"-- Database dump\n" +
+			"--\n\n" +
+			"CREATE SCHEMA public;\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "CREATE SCHEMA public;\n", string(out))
+	})
+
+	t.Run("mixed headers with restrict", func(t *testing.T) {
+		in := "\\restrict secure_key\n" +
+			"--\n" +
+			"-- PostgreSQL database dump\n" +
+			"-- Dumped from database version 16.1\n" +
+			"--\n\n" +
+			"SET statement_timeout = 0;\n" +
+			"CREATE TABLE test (id int);\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "SET statement_timeout = 0;\nCREATE TABLE test (id int);\n", string(out))
+	})
+
+	t.Run("backslash in content should not be stripped", func(t *testing.T) {
+		in := "--\n" +
+			"-- Header\n" +
+			"--\n\n" +
+			"CREATE TABLE test (path text);\n" +
+			"INSERT INTO test VALUES ('C:\\\\Windows\\\\System32');\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "CREATE TABLE test (path text);\nINSERT INTO test VALUES ('C:\\\\Windows\\\\System32');\n", string(out))
+	})
+
+	t.Run("unrestrict footer", func(t *testing.T) {
+		in := "\\restrict key123\n" +
+			"--\n" +
+			"-- PostgreSQL database dump\n" +
+			"--\n\n" +
+			"CREATE TABLE users (id int);\n" +
+			"INSERT INTO users VALUES (1);\n" +
+			"\\unrestrict\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "CREATE TABLE users (id int);\nINSERT INTO users VALUES (1);\n", string(out))
+	})
+
+	t.Run("trailing whitespace and comments", func(t *testing.T) {
+		in := "\\restrict abc\n" +
+			"-- Header\n" +
+			"CREATE SCHEMA public;\n" +
+			"CREATE TABLE test (id int);\n" +
+			"\n" +
+			"-- Footer comment\n" +
+			"\\unrestrict\n" +
+			"\n\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		// Footer SQL comments are preserved, only meta-commands and whitespace are stripped
+		require.Equal(t, "CREATE SCHEMA public;\nCREATE TABLE test (id int);\n\n-- Footer comment\n", string(out))
+	})
+
+	t.Run("complete pg_dump style with restrict headers", func(t *testing.T) {
+		in := "\\restrict secure_key_123\n" +
+			"--\n" +
+			"-- PostgreSQL database dump\n" +
+			"-- Dumped from database version 17.6\n" +
+			"-- Dumped by pg_dump version 17.6\n" +
+			"--\n\n" +
+			"SET statement_timeout = 0;\n" +
+			"CREATE SCHEMA public;\n" +
+			"CREATE TABLE users (id serial, name text);\n" +
+			"\n" +
+			"--\n" +
+			"-- PostgreSQL database dump complete\n" +
+			"--\n" +
+			"\\unrestrict\n" +
+			"\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		// SQL comments within content are preserved, only leading/trailing meta-commands are stripped
+		expected := "SET statement_timeout = 0;\nCREATE SCHEMA public;\nCREATE TABLE users (id serial, name text);\n\n--\n-- PostgreSQL database dump complete\n--\n"
+		require.Equal(t, expected, string(out))
+	})
+
+	t.Run("empty content between headers", func(t *testing.T) {
+		in := "\\restrict key\n" +
+			"-- Header\n" +
+			"\n\n" +
+			"-- Footer\n" +
+			"\\unrestrict\n"
+		out, err := dbutil.TrimLeadingSQLComments([]byte(in))
+		require.NoError(t, err)
+		require.Equal(t, "", string(out))
+	})
 }
 
 // connect to in-memory sqlite database for testing


### PR DESCRIPTION
* In `postgres: 17.6` it looks like a `\restrict` header was added to `pg_dump` output.
  * Discussed in the release notes here: https://www.postgresql.org/docs/release/17.6/ under "Prevent pg_dump scripts from being used to attack the user running the restore (Nathan Bossart) [§](https://postgr.es/c/575f54d4c)"
  * Change here: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=575f54d4c
* In using `dbmate`, it seems to be quite confused trying to parse these files with this `\restrict` header in them.
* The `TrimLeadingSQLComments` looks like maybe the best place to update and also trim these out.
* Confusingly, this change to `pg_dump` also ends a file with `\unrestrict` causing an issue parsing at the end too.

--

* The `mysql` test failure seems unrelated?