### PR TITLE
Set mysqldump SSL/TLS args based on 'tls' connection URL param.

### DIFF
--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -132,6 +132,14 @@ func (drv *Driver) mysqldumpArgs() []string {
 	args := []string{"--opt", "--routines", "--no-data",
 		"--skip-dump-date", "--skip-add-drop-table"}
 
+	tls := drv.databaseURL.Query().Get("tls")
+	if tls == "" || strings.EqualFold(tls, "false") {
+		args = append(args, "--ssl=false")
+	}
+	if strings.EqualFold(tls, "skip-verify") {
+		args = append(args, "--ssl-verify-server-cert=false")
+	}
+
 	socket := drv.databaseURL.Query().Get("socket")
 	if socket != "" {
 		args = append(args, "--socket="+socket)

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -154,6 +154,7 @@ func TestMySQLDumpArgs(t *testing.T) {
 		"--no-data",
 		"--skip-dump-date",
 		"--skip-add-drop-table",
+		"--ssl=false",
 		"--host=bob",
 		"mydb"}, drv.mysqldumpArgs())
 
@@ -163,6 +164,20 @@ func TestMySQLDumpArgs(t *testing.T) {
 		"--no-data",
 		"--skip-dump-date",
 		"--skip-add-drop-table",
+		"--ssl=false",
+		"--host=bob",
+		"--port=5678",
+		"--user=alice",
+		"--password=pw",
+		"mydb"}, drv.mysqldumpArgs())
+
+	drv.databaseURL = dbtest.MustParseURL(t, "mysql://alice:pw@bob:5678/mydb?tls=skip-verify")
+	require.Equal(t, []string{"--opt",
+		"--routines",
+		"--no-data",
+		"--skip-dump-date",
+		"--skip-add-drop-table",
+		"--ssl-verify-server-cert=false",
 		"--host=bob",
 		"--port=5678",
 		"--user=alice",
@@ -175,6 +190,7 @@ func TestMySQLDumpArgs(t *testing.T) {
 		"--no-data",
 		"--skip-dump-date",
 		"--skip-add-drop-table",
+		"--ssl=false",
 		"--socket=/var/run/mysqld/mysqld.sock",
 		"--user=alice",
 		"--password=pw",


### PR DESCRIPTION
It looks like the default for `--ssl-verify-server-cert` was changed from `FALSE` to `TRUE` in MariaDB Connector/C in version 3.4, corresponding to MariaDB 11.4:

https://github.com/mariadb-corporation/mariadb-connector-c/commit/1287c901dc8515823d28edcebfe4be65e6c5a6b3

> Since version 3.4 peer certificate verification is enabled by default.

https://mariadb.com/docs/server/security/securing-mariadb/securing-mariadb-encryption/data-in-transit-encryption/securing-connections-for-client-and-server#enabling-one-way-tls-for-mariadb-clients

> Starting from [MariaDB 11.4](https://mariadb.com/docs/release-notes/community-server/mariadb-11-4-series/what-is-mariadb-114) (Connector/C version 3.4) this mode is enabled by default.

As `dbmate` uses the `go-sql-driver/mysql` driver for executing queries, which sets [tls=false](https://github.com/go-sql-driver/mysql?tab=readme-ov-file#tls) by default, we don't see a change when applying migrations.

However, `dbmate` executes `mysqldump` to dump schemas, and that's where the change in MariaDB hits us.

We should disable SSL/TLS when invoking `mysqldump` if `tls` is `false`, and we should use `--ssl-verify-server-cert=false` if `tls` is `skip-verify`.

This fixes the following CI test failures:

```
=== RUN   TestMySQLDumpSchema
Dropping: dbmate_test
Creating: dbmate_test
    mysql_test.go:202: 
        	Error Trace:	/src/pkg/driver/mysql/mysql_test.go:202
        	Error:      	Received unexpected error:
        	            	mysqldump: Got error: 2026: "TLS/SSL error: self-signed certificate in certificate chain" when trying to connect
        	Test:       	TestMySQLDumpSchema
--- FAIL: TestMySQLDumpSchema (0.04s)
=== RUN   TestMySQLDumpSchemaContainsNoAutoIncrement
Dropping: dbmate_test
Creating: dbmate_test
    mysql_test.go:246: 
        	Error Trace:	/src/pkg/driver/mysql/mysql_test.go:246
        	Error:      	Received unexpected error:
        	            	mysqldump: Got error: 2026: "TLS/SSL error: self-signed certificate in certificate chain" when trying to connect
        	Test:       	TestMySQLDumpSchemaContainsNoAutoIncrement
--- FAIL: TestMySQLDumpSchemaContainsNoAutoIncrement (0.04s)
```