### PR TITLE
Bump golang from 1.24.3 to 1.24.6.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/amacneil/dbmate/v2
 
 go 1.23.0
 
-toolchain go1.24.3
+toolchain go1.24.6
 
 require (
 	cloud.google.com/go/bigquery v1.69.0


### PR DESCRIPTION
Docker image uses Go toolchain from the image in Dockerfile,
but GitHub Actions actions/setup-go uses the toolchain version
from go.mod.

Fixes #685.
