### PR TITLE
Do not create migrations table on dump

### DIFF
--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -200,7 +200,7 @@ func (db *DB) DumpSchema() error {
 		return err
 	}
 
-	sqlDB, err := db.openDatabaseForMigration(drv)
+	sqlDB, err := drv.Open()
 	if err != nil {
 		return err
 	}

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -136,6 +136,37 @@ func TestDumpSchema(t *testing.T) {
 	require.Contains(t, string(schema), "-- Dbmate schema migrations")
 }
 
+func TestDumpSchemaDoesNotCreateMigrationTable(t *testing.T) {
+	db := newTestDB(t, sqliteTestURL(t))
+
+	// create custom schema file directory
+	dir := t.TempDir()
+
+	// create schema.sql in subdirectory to test creating directory
+	db.SchemaFile = filepath.Join(dir, "/schema/schema.sql")
+
+	// drop database
+	err := db.Drop()
+	require.NoError(t, err)
+
+	// create and migrate
+	err = db.Create()
+	require.NoError(t, err)
+
+	// schema.sql should not exist
+	_, err = os.Stat(db.SchemaFile)
+	require.True(t, os.IsNotExist(err))
+
+	// dump schema
+	err = db.DumpSchema()
+	require.NoError(t, err)
+
+	// verify schema
+	schema, err := os.ReadFile(db.SchemaFile)
+	require.NoError(t, err)
+	require.NotContains(t, string(schema), "-- Dbmate schema migrations")
+}
+
 func TestAutoDumpSchema(t *testing.T) {
 	db := newTestDB(t, sqliteTestURL(t))
 	db.AutoDumpSchema = true

--- a/pkg/driver/bigquery/bigquery.go
+++ b/pkg/driver/bigquery/bigquery.go
@@ -221,6 +221,14 @@ func (drv *Driver) schemaDump(db *sql.DB) ([]byte, error) {
 }
 
 func (drv *Driver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	exists, err := drv.MigrationsTableExists(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if migration table exists: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
 	migrationsTable := drv.migrationsTableName
 
 	// load applied migrations

--- a/pkg/driver/bigquery/bigquery_test.go
+++ b/pkg/driver/bigquery/bigquery_test.go
@@ -373,3 +373,22 @@ func TestGoogleBigQueryDumpSchema(t *testing.T) {
 			"    ('abc2');\n")
 	})
 }
+
+func TestGoogleBigQueryDumpSchemaNoMigrations(t *testing.T) {
+	t.Run("default migrations table", func(t *testing.T) {
+		drv := testGoogleBigQueryDriver(t)
+
+		// prepare database
+		db := prepTestGoogleBigQueryDB(t)
+		defer dbutil.MustClose(db)
+
+		// DumpSchema should return schema
+		config, err := drv.getConfig(db)
+		require.NoError(t, err)
+
+		schema, err := drv.DumpSchema(db)
+		require.NoError(t, err)
+		require.NotContains(t, string(schema), fmt.Sprintf("CREATE TABLE `%s.%s.schema_migrations`", config.projectID, config.dataSet))
+		require.NotContains(t, string(schema), "\n--\n-- Dbmate schema migrations\n")
+	})
+}

--- a/pkg/driver/clickhouse/clickhouse.go
+++ b/pkg/driver/clickhouse/clickhouse.go
@@ -197,6 +197,14 @@ func (drv *Driver) schemaDump(db *sql.DB, buf *bytes.Buffer, databaseName string
 }
 
 func (drv *Driver) schemaMigrationsDump(db *sql.DB, buf *bytes.Buffer) error {
+	exists, err := drv.MigrationsTableExists(db)
+	if err != nil {
+		return fmt.Errorf("failed to check if migration table exists: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
 	migrationsTable := drv.quotedMigrationsTableName()
 
 	// load applied migrations

--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -137,6 +137,21 @@ func TestClickHouseDumpSchema(t *testing.T) {
 	require.EqualError(t, err, "code: 81, message: Database fakedb doesn't exist")
 }
 
+func TestClickHouseDumpSchemaNoMigrations(t *testing.T) {
+	drv := testClickHouseDriver(t)
+	drv.migrationsTableName = "test_migrations"
+
+	// prepare database
+	db := prepTestClickHouseDB(t, drv)
+	defer dbutil.MustClose(db)
+
+	// DumpSchema should return schema
+	schema, err := drv.DumpSchema(db)
+	require.NoError(t, err)
+	require.NotContains(t, string(schema), "CREATE TABLE "+drv.databaseName()+".test_migrations")
+	require.NotContains(t, string(schema), "--\n-- Dbmate schema migrations\n")
+}
+
 func TestClickHouseDatabaseExists(t *testing.T) {
 	drv := testClickHouseDriver(t)
 

--- a/pkg/driver/mysql/mysql.go
+++ b/pkg/driver/mysql/mysql.go
@@ -158,6 +158,14 @@ func (drv *Driver) mysqldumpArgs() []string {
 }
 
 func (drv *Driver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	exists, err := drv.MigrationsTableExists(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if migration table exists: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
 	migrationsTable := drv.quotedMigrationsTableName()
 
 	// load applied migrations

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -247,6 +247,23 @@ func TestMySQLDumpSchemaContainsNoAutoIncrement(t *testing.T) {
 	require.NotContains(t, string(schema), "AUTO_INCREMENT=")
 }
 
+func TestMySQLDumpSchemaDoesNotCreateMigrationsTable(t *testing.T) {
+	drv := testMySQLDriver(t)
+	drv.migrationsTableName = "test_migrations"
+
+	// prepare database
+	db := prepTestMySQLDB(t)
+	defer dbutil.MustClose(db)
+	_, err := db.Exec(`create table foo_table (id int not null primary key)`)
+	require.NoError(t, err)
+
+	// DumpSchema should return schema
+	schema, err := drv.DumpSchema(db)
+	require.NoError(t, err)
+	require.NotContains(t, string(schema), "CREATE TABLE `test_migrations`")
+	require.Contains(t, string(schema), "CREATE TABLE `foo_table`")
+}
+
 func TestMySQLDatabaseExists(t *testing.T) {
 	drv := testMySQLDriver(t)
 

--- a/pkg/driver/postgres/postgres.go
+++ b/pkg/driver/postgres/postgres.go
@@ -171,6 +171,14 @@ func (drv *Driver) DropDatabase() error {
 }
 
 func (drv *Driver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	exists, err := drv.MigrationsTableExists(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if migration table exists: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
 	migrationsTable, err := drv.quotedMigrationsTableName(db)
 	if err != nil {
 		return nil, err

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -274,6 +274,27 @@ func TestPostgresDumpSchema(t *testing.T) {
 			"    ('abc1'),\n"+
 			"    ('abc2');\n")
 	})
+
+	t.Run("no migrations table on dump", func(t *testing.T) {
+		drv := testPostgresDriver(t)
+
+		// prepare database
+		db := prepTestPostgresDB(t)
+		defer dbutil.MustClose(db)
+
+		// DumpSchema should return schema
+		schema, err := drv.DumpSchema(db)
+		require.NoError(t, err)
+		require.NotContains(t, string(schema), "CREATE TABLE public.schema_migrations")
+		require.Contains(t, string(schema), "\n--\n"+
+			"-- PostgreSQL database dump complete\n"+
+			"--\n\n")
+		require.NotContains(t, string(schema), "-- Dbmate schema migrations\n"+
+			"--\n\n"+
+			"INSERT INTO public.schema_migrations (version) VALUES\n"+
+			"    ('abc1'),\n"+
+			"    ('abc2');\n")
+	})
 }
 
 func TestPostgresDatabaseExists(t *testing.T) {

--- a/pkg/driver/sqlite/sqlite.go
+++ b/pkg/driver/sqlite/sqlite.go
@@ -105,6 +105,14 @@ func (drv *Driver) DropDatabase() error {
 }
 
 func (drv *Driver) schemaMigrationsDump(db *sql.DB) ([]byte, error) {
+	exists, err := drv.MigrationsTableExists(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if migration table exists: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
 	migrationsTable := drv.quotedMigrationsTableName()
 
 	// load applied migrations


### PR DESCRIPTION
When running `dbmate dump`, no changes to the database should be made.

Use case: running `dbmate dump` with credentials that do not have _CREATE_ permissions.