### PR TITLE
Support requiring SSL, and verifying CA, for MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       CLICKHOUSE_CLUSTER_01_TEST_URL: clickhouse://ch-cluster-01:9000/dbmate_test
       CLICKHOUSE_CLUSTER_02_TEST_URL: clickhouse://ch-cluster-02:9000/dbmate_test
       MYSQL_TEST_URL: mysql://root:root@mysql/dbmate_test
+      DBMATE_MYSQL_SSL_MODE: DISABLED
       POSTGRES_TEST_URL: postgres://postgres:postgres@postgres/dbmate_test?sslmode=disable
       BIGQUERY_TEST_URL: bigquery://test/us-east5/dbmate_test?disable_auth=true&endpoint=http%3A%2F%2Fbigquery%3A9050
       SPANNER_POSTGRES_TEST_URL: spanner-postgres://spanner-emulator/dbmate_test?sslmode=disable

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -146,6 +146,7 @@ func TestMySQLCreateDropDatabase(t *testing.T) {
 }
 
 func TestMySQLDumpArgs(t *testing.T) {
+	t.Setenv("DBMATE_MYSQL_SSL_MODE", "PREFERRED")
 	drv := testMySQLDriver(t)
 	drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
 
@@ -179,6 +180,114 @@ func TestMySQLDumpArgs(t *testing.T) {
 		"--user=alice",
 		"--password=pw",
 		"mydb"}, drv.mysqldumpArgs())
+}
+
+func TestMySQLDumpArgsWithSsl(t *testing.T) {
+	t.Run("mode=DISABLED,ca=empty", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "DISABLED")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"DISABLED",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
+	t.Run("mode=DISABLED,ca=set", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "DISABLED")
+		t.Setenv("DBMATE_MYSQL_CA_PATH", "/tmp/404")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"DISABLED",
+			"--ssl-ca",
+			"/tmp/404",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
+	t.Run("mode=VERIFY_IDENTITY,ca=empty", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "VERIFY_IDENTITY")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"VERIFY_IDENTITY",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
+	t.Run("mode=VERIFY_IDENTITY,ca=set", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "VERIFY_IDENTITY")
+		t.Setenv("DBMATE_MYSQL_CA_PATH", "/tmp/404")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"VERIFY_IDENTITY",
+			"--ssl-ca",
+			"/tmp/404",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
+	t.Run("mode=REQUIRED,ca=empty", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "REQUIRED")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"REQUIRED",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
+	t.Run("mode=REQUIRED,ca=set", func(t *testing.T) {
+		t.Setenv("DBMATE_MYSQL_SSL_MODE", "REQUIRED")
+		t.Setenv("DBMATE_MYSQL_CA_PATH", "/tmp/404")
+		drv := testMySQLDriver(t)
+		drv.databaseURL = dbtest.MustParseURL(t, "mysql://bob/mydb")
+		require.Equal(t, []string{
+			"--opt",
+			"--routines",
+			"--no-data",
+			"--skip-dump-date",
+			"--skip-add-drop-table",
+			"--ssl-mode",
+			"REQUIRED",
+			"--ssl-ca",
+			"/tmp/404",
+			"--host=bob",
+			"mydb",
+		}, drv.mysqldumpArgs())
+	})
 }
 
 func TestMySQLDumpSchema(t *testing.T) {


### PR DESCRIPTION
This PR adds support for requiring a secure connection and man-in-the-middle protection in the form of the `DBMATE_MYSQL_SSL_MODE` and `DBMATE_MYSQL_CA_PATH` parameter.

- `DBMATE_MYSQL_SSL_MODE` is an implementation of <https://dev.mysql.com/doc/refman/8.4/en/connection-options.html#option_general_ssl-mode>
- `DBMATE_MYSQL_CA_PATH` implements <https://dev.mysql.com/doc/refman/8.4/en/connection-options.html#option_general_ssl-ca>

This PR will also fix tests failing on the main branch due to certificate verification problems.

Important caveat, the CLI parameter `--ssl-mode` used for mysqldump is not present in mariadb dump. If there is a way to detect whether mariadb-dump is used, I could change the parameters accordingly but there does not seem to be a distinction at the moment. Suggestions welcome.

I'll refrain from further work until there is some feedback on the approach and whether there is interest in this change.

Todo:
- [ ] Decide how to handle mariadb dump compatibility
- [ ] Add documentation