### PR TITLE
Update tests to deal with \unrestrict in postgres 17's dump output

### DIFF
--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -228,9 +228,8 @@ func TestPostgresDumpSchema(t *testing.T) {
 		require.Contains(t, string(schema), "CREATE TABLE public.schema_migrations")
 		require.Contains(t, string(schema), "\n--\n"+
 			"-- PostgreSQL database dump complete\n"+
-			"--\n\n\n"+
-			"--\n"+
-			"-- Dbmate schema migrations\n"+
+			"--\n\n")
+		require.Contains(t, string(schema), "-- Dbmate schema migrations\n"+
 			"--\n\n"+
 			"INSERT INTO public.schema_migrations (version) VALUES\n"+
 			"    ('abc1'),\n"+
@@ -266,9 +265,8 @@ func TestPostgresDumpSchema(t *testing.T) {
 		require.Contains(t, string(schema), "CREATE TABLE \"camelSchema\".\"testMigrations\"")
 		require.Contains(t, string(schema), "\n--\n"+
 			"-- PostgreSQL database dump complete\n"+
-			"--\n\n\n"+
-			"--\n"+
-			"-- Dbmate schema migrations\n"+
+			"--\n\n")
+		require.Contains(t, string(schema), "-- Dbmate schema migrations\n"+
 			"--\n\n"+
 			"INSERT INTO \"camelSchema\".\"testMigrations\" (version) VALUES\n"+
 			"    ('abc1'),\n"+


### PR DESCRIPTION
See https://www.postgresql.org/docs/17/release-17-6.html and https://www.postgresql.org/support/security/CVE-2025-8714/.