### PR TITLE
Replace hardcoded hostname in ping tests

### DIFF
--- a/pkg/driver/clickhouse/clickhouse_test.go
+++ b/pkg/driver/clickhouse/clickhouse_test.go
@@ -363,7 +363,7 @@ func TestClickHousePing(t *testing.T) {
 	require.NoError(t, err)
 
 	// ping invalid host should return error
-	drv.databaseURL.Host = "clickhouse:404"
+	drv.databaseURL.Host = drv.databaseURL.Hostname() + ":404"
 	err = drv.Ping()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connect: connection refused")

--- a/pkg/driver/mysql/mysql_test.go
+++ b/pkg/driver/mysql/mysql_test.go
@@ -393,7 +393,7 @@ func TestMySQLPing(t *testing.T) {
 	require.NoError(t, err)
 
 	// ping invalid host should return error
-	drv.databaseURL.Host = "mysql:404"
+	drv.databaseURL.Host = drv.databaseURL.Hostname() + ":404"
 	err = drv.Ping()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connect: connection refused")

--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -555,7 +555,7 @@ func TestPostgresPing(t *testing.T) {
 	require.NoError(t, err)
 
 	// ping invalid host should return error
-	drv.databaseURL.Host = "postgres:404"
+	drv.databaseURL.Host = drv.databaseURL.Hostname() + ":404"
 	err = drv.Ping()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "connect: connection refused")


### PR DESCRIPTION
When testing with a custom `MYSQL_TEST_URL`, these tests would otherwise fail.