### PR TITLE
Remove redundant t.Chdir()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -62,21 +62,16 @@ func TestRedactLogString(t *testing.T) {
 
 func TestLoadEnvFiles(t *testing.T) {
 	setup := func(t *testing.T) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		env := os.Environ()
 
+		// t.Chdir automatically restores the original directory when the test completes
 		t.Chdir("fixtures/loadEnvFiles")
 
 		// Clear environment after t.Chdir because t.Chdir sets PWD
 		os.Clearenv()
 
+		// Restore environment variables when test completes
 		t.Cleanup(func() {
-			t.Chdir(cwd)
-
 			os.Clearenv()
 
 			for _, e := range env {


### PR DESCRIPTION
Remove redundant `t.Chdir(cwd)` call and add comments to clarify directory cleanup in `TestLoadEnvFiles`.

Identified by https://github.com/amacneil/dbmate/pull/709#discussion_r2627663277 although that bugbot comment was incorrect.

The `t.Chdir` function automatically registers a cleanup to restore the original directory, making the explicit `t.Chdir(cwd)` call in the `t.Cleanup` block redundant. This change simplifies the test setup and clarifies that `t.Chdir` handles its own directory restoration.

---
<a href="https://cursor.com/background-agent?bcId=bc-43db5ef2-82e0-4c1a-b568-b39d4f0df70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43db5ef2-82e0-4c1a-b568-b39d4f0df70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies `TestLoadEnvFiles` setup by relying on `t.Chdir`'s built-in directory restoration and tightening environment handling.
> 
> - Removes manual `cwd` tracking and redundant `t.Chdir(cwd)` from `t.Cleanup`
> - Keeps `os.Clearenv()` after `t.Chdir` (since it sets `PWD`) and restores env vars in `t.Cleanup`
> - Adds clarifying comments about directory and environment cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159749d0cfb70f530172d164211bc2bdafb33532. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->