### PR TITLE
Bump golang toolchain in go.mod from 1.24.3 to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/amacneil/dbmate/v2
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.5
 
 require (
 	cloud.google.com/go/bigquery v1.72.0


### PR DESCRIPTION
Docker image is built with 1.25.5, but go.mod needs to also
be updated for people building dbmate from source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Build tooling update**
> 
> - Bumps Go `toolchain` in `go.mod` from `go1.24.3` to `go1.25.5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e4aa8be9d3bcabfd32538f63ce2268c36a90eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->