### PR TITLE
Remove unnecessary NODE_AUTH_TOKEN line

### DIFF
--- a/pkg/dbmate/version.go
+++ b/pkg/dbmate/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "2.29.1"
+const Version = "2.29.2"

--- a/typescript/publish.ts
+++ b/typescript/publish.ts
@@ -8,9 +8,6 @@ async function main() {
   );
 
   for (const pkg of packages) {
-    // Unset NODE_AUTH_TOKEN to avoid conflicts with OIDC trusted publishing
-    delete process.env.NODE_AUTH_TOKEN;
-    await exec("corepack", ["npm", "--version"]);
     await exec("corepack", [
       "npm",
       "publish",


### PR DESCRIPTION
This line was not actually necessary. I didn't notice that it worked fine without.

Turns out upgrading NPM was the main required step to get this working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts release pipeline and TypeScript publish behavior, plus a patch version bump.
> 
> - `typescript/publish.ts`: remove `NODE_AUTH_TOKEN` unsetting and `npm --version` check; add `--dry-run` to `npm publish`
> - `.github/workflows/ci.yml`: comment out the tag-only condition for the NPM publish step
> - `pkg/dbmate/version.go`: bump `Version` to `2.29.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f226dcf21fce197ee9fbac0b510c86600dee655. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->