### PR TITLE
Postgres restrict key compatibility

### DIFF
--- a/pkg/driver/postgres/postgres_test.go
+++ b/pkg/driver/postgres/postgres_test.go
@@ -128,7 +128,11 @@ func TestPgDumpVersionSupportsRestrictKey(t *testing.T) {
 		expected bool
 	}{
 		{"nil version", nil, false},
+		{"PostgreSQL 15.13", &pgDumpVersion{major: 15, minor: 13}, false},
+		{"PostgreSQL 15.14", &pgDumpVersion{major: 15, minor: 14}, true},
 		{"PostgreSQL 16.0", &pgDumpVersion{major: 16, minor: 0}, false},
+		{"PostgreSQL 16.9", &pgDumpVersion{major: 16, minor: 9}, false},
+		{"PostgreSQL 16.10", &pgDumpVersion{major: 16, minor: 10}, true},
 		{"PostgreSQL 17.0", &pgDumpVersion{major: 17, minor: 0}, false},
 		{"PostgreSQL 17.5", &pgDumpVersion{major: 17, minor: 5}, false},
 		{"PostgreSQL 17.6", &pgDumpVersion{major: 17, minor: 6}, true},


### PR DESCRIPTION
Expand `pg_dump --restrict-key` detection to PostgreSQL 15.14+ and 16.10+ to ensure deterministic schema dumps.

Fixes: https://github.com/amacneil/dbmate/issues/728

---
<a href="https://cursor.com/background-agent?bcId=bc-aacb38de-028b-487e-9c78-f4dc974d64d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aacb38de-028b-487e-9c78-f4dc974d64d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

