### PR TITLE
Discourage Dependabot from bumping golang in Dockerfile to a release candidate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: golang
+        versions: ["*rc*"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents Dependabot from proposing Go release-candidate bumps in Dockerfiles.
> 
> - Updates `.github/dependabot.yml` to ignore `golang` versions matching `*rc*` for the `docker` ecosystem, schedule unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeb1f91c1ef10ae376ef5c80ed6e4ca923207ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->