### PR TITLE
feat: migration templates with CLI flags and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For a comparison between dbmate and other popular database schema migration tool
     - [BigQuery](#bigquery)
     - [Spanner](#spanner)
   - [Creating Migrations](#creating-migrations)
+    - [Migration templates](#migration-templates)
   - [Running Migrations](#running-migrations)
   - [Rolling Back Migrations](#rolling-back-migrations)
   - [Migration Options](#migration-options)
@@ -136,6 +137,8 @@ The following options are available with all commands. You must use command line
 - `--env-file ".env"` - specify an alternate environment variables file(s) to load.
 - `--migrations-dir, -d "./db/migrations"` - where to keep the migration files. _(env: `DBMATE_MIGRATIONS_DIR`)_
 - `--migrations-table "schema_migrations"` - database table to record migrations in. _(env: `DBMATE_MIGRATIONS_TABLE`)_
+- `--templates-dir "./db/migration_templates"` - directory containing `.sql` files used as migration templates by `dbmate new`. _(env: `DBMATE_TEMPLATES_DIR`)_
+- `--template-default "baseline"` - default template name (filename without `.sql`) when `dbmate new` is run without `--template`. _(env: `DBMATE_TEMPLATE_DEFAULT`)_
 - `--schema-file, -s "./db/schema.sql"` - a path to keep the schema.sql file. _(env: `DBMATE_SCHEMA_FILE`)_
 - `--no-dump-schema` - don't auto-update the schema.sql file on migrate/rollback _(env: `DBMATE_NO_DUMP_SCHEMA`)_
 - `--strict` - fail if migrations would be applied out of order _(env: `DBMATE_STRICT`)_
@@ -395,6 +398,18 @@ To create a new migration, run `dbmate new create_users_table`. You can name the
 -- migrate:down
 ```
 
+#### Migration templates
+
+By default, `dbmate new` uses the built-in skeleton above. You can instead generate a file from your own templates: add one or more `.sql` files to a directory, point dbmate at that directory with `--templates-dir` or `DBMATE_TEMPLATES_DIR`, then pass the template basename (without `.sql`) to `dbmate new`:
+
+```sh
+dbmate --templates-dir ./db/migration_templates new --template create_table create_widgets_table
+```
+
+That reads `./db/migration_templates/create_table.sql` and writes a new timestamped migration whose initial contents match the template file.
+
+If you set `--template-default` or `DBMATE_TEMPLATE_DEFAULT` to a template name, `dbmate new my_migration` uses that template when you omit `--template`. Using a template requires `DBMATE_TEMPLATES_DIR` (or `--templates-dir`) to be set; otherwise dbmate exits with an error.
+
 To write a migration, simply add your SQL to the `migrate:up` section:
 
 ```sql
@@ -546,7 +561,7 @@ mysqldump [default_options] [your_arguments_go_here] dbname
 for pg_dump:
 ```sh
 pg_dump [default_options] [your_arguments_go_here] dbname
-``` 
+```
 
 > Note: The `schema.sql` file will contain a complete schema for your database, even if some tables or columns were created outside of dbmate migrations.
 
@@ -628,7 +643,7 @@ func main() {
 
 ### Migration files
 
-Migration files are very simple, and are stored in `./db/migrations` by default. You can create a new migration file named `[date]_create_users.sql` by running `dbmate new create_users`.
+Migration files are very simple, and are stored in `./db/migrations` by default. You can create a new migration file named `[date]_create_users.sql` by running `dbmate new create_users`. Optional [migration templates](#migration-templates) let you start from shared `.sql` snippets instead of the default skeleton.
 Here is an example:
 
 ```sql

--- a/main.go
+++ b/main.go
@@ -79,6 +79,16 @@ func NewApp() *cli.App {
 			Usage:   "specify the database table to record migrations in",
 		},
 		&cli.StringFlag{
+			Name:    "templates-dir",
+			EnvVars: []string{"DBMATE_TEMPLATES_DIR"},
+			Usage:   "specify the directory containing migration templates",
+		},
+		&cli.StringFlag{
+			Name:    "template-default",
+			EnvVars: []string{"DBMATE_TEMPLATE_DEFAULT"},
+			Usage:   "specify the default migration template",
+		},
+		&cli.StringFlag{
 			Name:    "schema-file",
 			Aliases: []string{"s"},
 			EnvVars: []string{"DBMATE_SCHEMA_FILE"},
@@ -108,9 +118,16 @@ func NewApp() *cli.App {
 			Name:    "new",
 			Aliases: []string{"n"},
 			Usage:   "Generate a new migration file",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "template",
+					Usage: "specify the migration template to use",
+				},
+			},
 			Action: action(func(db *dbmate.DB, c *cli.Context) error {
 				name := c.Args().First()
-				return db.NewMigration(name)
+				template := c.String("template")
+				return db.NewMigrationTemplate(name, template)
 			}),
 		},
 		{
@@ -319,6 +336,8 @@ func configureDB(c *cli.Context) (*dbmate.DB, error) {
 	db.MigrationsDir = c.StringSlice("migrations-dir")
 	db.MigrationsTableName = c.String("migrations-table")
 	db.SchemaFile = c.String("schema-file")
+	db.TemplatesDir = c.String("templates-dir")
+	db.DefaultTemplate = c.String("template-default")
 	db.WaitBefore = c.Bool("wait")
 	waitTimeout := c.Duration("wait-timeout")
 	if waitTimeout != 0 {

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -116,6 +116,110 @@ func TestGetDriver(t *testing.T) {
 	})
 }
 
+func TestNewMigration(t *testing.T) {
+	db := newTestDB(t, sqliteTestURL(t))
+
+	// default migrations dir
+	db.MigrationsDir = []string{t.TempDir()}
+
+	err := db.NewMigration("hello_world")
+	require.NoError(t, err)
+
+	// verify file exists
+	files, err := os.ReadDir(db.MigrationsDir[0])
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Contains(t, files[0].Name(), "_hello_world.sql")
+
+	content, err := os.ReadFile(filepath.Join(db.MigrationsDir[0], files[0].Name()))
+	require.NoError(t, err)
+	require.Contains(t, string(content), "-- migrate:up")
+}
+
+func TestNewMigrationTemplate(t *testing.T) {
+	db := newTestDB(t, sqliteTestURL(t))
+	db.MigrationsDir = []string{t.TempDir()}
+
+	templatesDir := t.TempDir()
+	db.TemplatesDir = templatesDir
+
+	// write a test template
+	templateContent := "-- custom template"
+	err := os.WriteFile(filepath.Join(templatesDir, "custom.sql"), []byte(templateContent), 0o644)
+	require.NoError(t, err)
+
+	t.Run("without template", func(t *testing.T) {
+		err := db.NewMigrationTemplate("test_no_template", "")
+		require.NoError(t, err)
+
+		files, err := os.ReadDir(db.MigrationsDir[0])
+		require.NoError(t, err)
+
+		var found bool
+		for _, f := range files {
+			if strings.Contains(f.Name(), "_test_no_template.sql") {
+				found = true
+				content, err := os.ReadFile(filepath.Join(db.MigrationsDir[0], f.Name()))
+				require.NoError(t, err)
+				require.Contains(t, string(content), "-- migrate:up")
+			}
+		}
+		require.True(t, found)
+	})
+
+	t.Run("with template", func(t *testing.T) {
+		err := db.NewMigrationTemplate("test_with_template", "custom")
+		require.NoError(t, err)
+
+		files, err := os.ReadDir(db.MigrationsDir[0])
+		require.NoError(t, err)
+
+		var found bool
+		for _, f := range files {
+			if strings.Contains(f.Name(), "_test_with_template.sql") {
+				found = true
+				content, err := os.ReadFile(filepath.Join(db.MigrationsDir[0], f.Name()))
+				require.NoError(t, err)
+				require.Equal(t, templateContent, string(content))
+			}
+		}
+		require.True(t, found)
+	})
+
+	t.Run("default template", func(t *testing.T) {
+		db.DefaultTemplate = "custom"
+		err := db.NewMigrationTemplate("test_default_template", "")
+		require.NoError(t, err)
+
+		files, err := os.ReadDir(db.MigrationsDir[0])
+		require.NoError(t, err)
+
+		var found bool
+		for _, f := range files {
+			if strings.Contains(f.Name(), "_test_default_template.sql") {
+				found = true
+				content, err := os.ReadFile(filepath.Join(db.MigrationsDir[0], f.Name()))
+				require.NoError(t, err)
+				require.Equal(t, templateContent, string(content))
+			}
+		}
+		require.True(t, found)
+	})
+
+	t.Run("missing DBMATE_TEMPLATES_DIR", func(t *testing.T) {
+		db.TemplatesDir = ""
+		err := db.NewMigrationTemplate("test_missing_dir", "custom")
+		require.EqualError(t, err, "template specified but DBMATE_TEMPLATES_DIR is not set")
+	})
+
+	t.Run("missing template file", func(t *testing.T) {
+		db.TemplatesDir = templatesDir
+		err := db.NewMigrationTemplate("test_missing_file", "missing")
+		require.ErrorContains(t, err, "template not found")
+	})
+}
+
+
 func TestWait(t *testing.T) {
 	db := newTestDB(t, sqliteTestURL(t))
 

--- a/pkg/dbmate/db_test.go
+++ b/pkg/dbmate/db_test.go
@@ -219,7 +219,6 @@ func TestNewMigrationTemplate(t *testing.T) {
 	})
 }
 
-
 func TestWait(t *testing.T) {
 	db := newTestDB(t, sqliteTestURL(t))
 


### PR DESCRIPTION
### Summary
Adds optional SQL migration templates for `dbmate new`, plus README documentation.

### Changes
- **feat:** Global flags `--templates-dir`, `--template-default` (and env vars); `dbmate new --template`; `NewMigrationTemplate` and `DB` fields; tests in `db_test.go`.
- **docs:** README section on templates, TOC, CLI options list, and link from Migration files.

### Checklist
- [x] Tests pass