### PR TITLE
fix: redact full password when it contains @ sign

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func getDatabaseURL(c *cli.Context) (u *url.URL, err error) {
 
 // redactLogString attempts to redact passwords from errors
 func redactLogString(in string) string {
-	re := regexp.MustCompile("([a-zA-Z]+://[^:]+:)[^@]+@")
+	re := regexp.MustCompile("([a-zA-Z]+://[^:]+:).+@")
 
 	return re.ReplaceAllString(in, "${1}********@")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -55,6 +55,9 @@ func TestRedactLogString(t *testing.T) {
 		// invalid port, but probably not a password since there is no @
 		{"parse \"mysql://localhost:abc/database\": invalid",
 			"parse \"mysql://localhost:abc/database\": invalid"},
+		// password containing @ sign - should redact entire password
+		{"parse \"postgres://username:oRAND44@W)£+@1.1.1.1:5432/db_name\": invalid",
+			"parse \"postgres://username:********@1.1.1.1:5432/db_name\": invalid"},
 	}
 
 	for _, ex := range examples {


### PR DESCRIPTION
Fixes #784

## Problem

`redactLogString` uses `[^@]+` to match the password portion, stopping at the first `@`. When a password contains `@` (e.g. `pass@word`), only the part before the first `@` is redacted, leaking the rest in error messages:

```
Input:  postgres://user:oRAND44@leaked_part@host:5432/db
Output: postgres://user:********@leaked_part@host:5432/db  ← password leaked!
```

## Fix

Change `[^@]+` to `.+` (greedy) so the regex matches everything up to the **last** `@`, redacting the entire password:

```
Output: postgres://user:********@host:5432/db  ← fully redacted
```

Added test case for passwords containing `@`.