### PR TITLE
Fix TypeScript lint Node type resolution

### DIFF
--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["*.ts"],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the Node type environment to the TypeScript config so ESLint/TypeScript can resolve `node:*` imports and `process`.

## Verification
- `npx tsc --noEmit -p tsconfig.eslint.json`
- `npm run lint:ci`
- `npm run generate -- --skip-bin && npm run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a49078f-4289-4e30-84a4-d6152a8cb522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a49078f-4289-4e30-84a4-d6152a8cb522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

