### PR TITLE
Fix redaction when query values contain @

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func getDatabaseURL(c *cli.Context) (u *url.URL, err error) {
 
 // redactLogString attempts to redact passwords from errors
 func redactLogString(in string) string {
-	re := regexp.MustCompile("([a-zA-Z]+://[^:]+:).+@")
+	re := regexp.MustCompile(`([a-zA-Z]+://[^:]+:)[^\s?#]+@`)
 
 	return re.ReplaceAllString(in, "${1}********@")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -58,6 +58,9 @@ func TestRedactLogString(t *testing.T) {
 		// password containing @ sign - should redact entire password
 		{"parse \"postgres://username:oRAND44@W)£+@1.1.1.1:5432/db_name\": invalid",
 			"parse \"postgres://username:********@1.1.1.1:5432/db_name\": invalid"},
+		// @ signs in query values are not part of the password
+		{"parse \"postgresql://user:password@host:5432/mydb?foo=b@r\": invalid",
+			"parse \"postgresql://user:********@host:5432/mydb?foo=b@r\": invalid"},
 	}
 
 	for _, ex := range examples {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add coverage for PostgreSQL URLs whose query values contain `@`
- Keep password redaction from consuming query-string content while still redacting passwords that contain `@`

Based on #785.

## Tests
- `go test . -run TestRedactLogString`
- `go test ./...` (fails in `pkg/driver/sqlite`: environment sqlite library reports `no such module: fts5`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5542d031-bad6-4261-b77e-4bb8d774844c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5542d031-bad6-4261-b77e-4bb8d774844c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

