### PR TITLE
fix: report dedicated error for multiple migrate:down annotations

### DIFF
--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -74,6 +74,7 @@ var (
 	ErrParseMissingDown    = errors.New("dbmate requires each migration to define a down block with '-- migrate:down'")
 	ErrParseWrongOrder     = errors.New("dbmate requires '-- migrate:up' to appear before '-- migrate:down'")
 	ErrParseUnexpectedStmt = errors.New("dbmate does not support statements preceding the '-- migrate:up' block")
+	ErrParseMultipleDown   = errors.New("dbmate does not support multiple '-- migrate:down' annotations in a single migration section")
 )
 
 func parseMigrationContents(contents string) ([]*ParsedMigration, error) {
@@ -244,7 +245,7 @@ func getMigrationSectionSubstrings(contents string) ([]string, error) {
 		begin, end := sectionBeginEnd[0], sectionBeginEnd[1]
 		contentsSubstring := substring(contents, begin, end)
 		if len(downRegExp.FindAllStringIndex(contentsSubstring, -1)) > 1 {
-			return nil, ErrParseMissingUp
+			return nil, ErrParseMultipleDown
 		}
 		sectionSubstrings = append(sectionSubstrings, contentsSubstring)
 	}

--- a/pkg/dbmate/migration.go
+++ b/pkg/dbmate/migration.go
@@ -74,7 +74,7 @@ var (
 	ErrParseMissingDown    = errors.New("dbmate requires each migration to define a down block with '-- migrate:down'")
 	ErrParseWrongOrder     = errors.New("dbmate requires '-- migrate:up' to appear before '-- migrate:down'")
 	ErrParseUnexpectedStmt = errors.New("dbmate does not support statements preceding the '-- migrate:up' block")
-	ErrParseMultipleDown   = errors.New("dbmate does not support multiple '-- migrate:down' annotations in a single migration section")
+	ErrParseMultipleDown   = errors.New("dbmate requires every '-- migrate:down' to be preceded by a '-- migrate:up'")
 )
 
 func parseMigrationContents(contents string) ([]*ParsedMigration, error) {

--- a/pkg/dbmate/migration_test.go
+++ b/pkg/dbmate/migration_test.go
@@ -269,7 +269,7 @@ drop table statuses;
 		require.Error(t, err, "dbmate requires each migration to define a down block with '-- migrate:down'")
 	})
 
-	t.Run("require an up block in each section", func(t *testing.T) {
+	t.Run("reject multiple down annotations in a single section", func(t *testing.T) {
 		migration := `-- migrate:up
 create table users (id serial, name text);
 -- migrate:down
@@ -279,6 +279,6 @@ drop table statuses;
 `
 
 		_, err := parseMigrationContents(migration)
-		require.Error(t, err, "dbmate requires each migration to define an up block with '-- migrate:up'")
+		require.ErrorIs(t, err, ErrParseMultipleDown)
 	})
 }


### PR DESCRIPTION
When a migration section contains more than one `-- migrate:down` annotation, the parser returns `ErrParseMissingUp` ("missing up block"), which is misleading because the up block is present. This adds `ErrParseMultipleDown` so the reported failure matches what the user typed.