### PR TITLE
feat: add --wait-interval flag and DBMATE_WAIT_INTERVAL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The following options are available with all commands. You must use command line
 - `--strict` - fail if migrations would be applied out of order _(env: `DBMATE_STRICT`)_
 - `--wait` - wait for the db to become available before executing the subsequent command _(env: `DBMATE_WAIT`)_
 - `--wait-timeout 60s` - timeout for --wait flag _(env: `DBMATE_WAIT_TIMEOUT`)_
+- `--wait-interval 1s` - time to wait between connection attempts for --wait flag _(env: `DBMATE_WAIT_INTERVAL`)_
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -101,6 +101,12 @@ func NewApp() *cli.App {
 			Usage:   "timeout for --wait flag",
 			Value:   defaultDB.WaitTimeout,
 		},
+		&cli.DurationFlag{
+			Name:    "wait-interval",
+			EnvVars: []string{"DBMATE_WAIT_INTERVAL"},
+			Usage:   "time to wait between connection attempts for --wait flag",
+			Value:   defaultDB.WaitInterval,
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -323,6 +329,10 @@ func configureDB(c *cli.Context) (*dbmate.DB, error) {
 	waitTimeout := c.Duration("wait-timeout")
 	if waitTimeout != 0 {
 		db.WaitTimeout = waitTimeout
+	}
+	waitInterval := c.Duration("wait-interval")
+	if waitInterval != 0 {
+		db.WaitInterval = waitInterval
 	}
 
 	return db, nil

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
@@ -210,5 +211,46 @@ func TestConfigureDB_Driver(t *testing.T) {
 		err := app.Run([]string{"dbmate", "--driver", "clickhouse", "test-config"})
 		require.NoError(t, err)
 		require.Equal(t, "clickhouse", configuredDB.DriverName)
+	})
+}
+
+func TestConfigureDB_WaitInterval(t *testing.T) {
+	var configuredDB *dbmate.DB
+
+	app := NewApp()
+	app.Commands = []*cli.Command{
+		{
+			Name: "test-config",
+			Action: func(c *cli.Context) error {
+				var err error
+				configuredDB, err = configureDB(c)
+				return err
+			},
+		},
+	}
+
+	t.Run("default", func(t *testing.T) {
+		configuredDB = nil
+		err := app.Run([]string{"dbmate", "test-config"})
+		require.NoError(t, err)
+		require.Equal(t, time.Second, configuredDB.WaitInterval)
+	})
+
+	t.Run("from env variable", func(t *testing.T) {
+		configuredDB = nil
+		t.Setenv("DBMATE_WAIT_INTERVAL", "2s")
+
+		err := app.Run([]string{"dbmate", "test-config"})
+		require.NoError(t, err)
+		require.Equal(t, 2*time.Second, configuredDB.WaitInterval)
+	})
+
+	t.Run("flag overrides env variable", func(t *testing.T) {
+		configuredDB = nil
+		t.Setenv("DBMATE_WAIT_INTERVAL", "2s")
+
+		err := app.Run([]string{"dbmate", "--wait-interval", "3s", "test-config"})
+		require.NoError(t, err)
+		require.Equal(t, 3*time.Second, configuredDB.WaitInterval)
 	})
 }


### PR DESCRIPTION
Adds a `--wait-interval` CLI flag and `DBMATE_WAIT_INTERVAL` env var to configure the delay between connection attempts for `--wait`. The `WaitInterval` field is already exposed to Go API users; this plumbs it through the CLI, mirroring the existing `--wait-timeout` / `DBMATE_WAIT_TIMEOUT`.

Validation (local, macOS):
- `go build ./...` and `go vet ./...` pass
- `golangci-lint run`: 0 issues
- `go test` for the main package passes, including a new `TestConfigureDB_WaitInterval` (default / env / flag-overrides-env)
- `dbmate --help` shows: `--wait-interval value ... (default: 1s) [$DBMATE_WAIT_INTERVAL]`

related: #516