### PR TITLE
fix: correct typos in README and source comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ protocol://username:password@host:port/database_name?options
 ```
 
 - `protocol` must be one of `mysql`, `postgres`, `postgresql`, `sqlite`, `sqlite3`, `clickhouse`
-- `username` and `password` must be URL encoded (you will get an error if you use special charactors)
+- `username` and `password` must be URL encoded (you will get an error if you use special characters)
 - `host` can be either a hostname or IP address
 - `options` are driver-specific (refer to the underlying Go SQL drivers if you wish to use these)
 
@@ -286,7 +286,7 @@ DATABASE_URL="clickhouse://username:password@127.0.0.1:9000/database_name"
 
 ##### HTTP / HTTPS
 
-You can use `clickhouse+http://` (deafult port 8123) or `clickhouse+https://` (default port 8443).
+You can use `clickhouse+http://` (default port 8123) or `clickhouse+https://` (default port 8443).
 
 ```sh
 # HTTP (Defaults to port 8123)

--- a/pkg/dbmate/db.go
+++ b/pkg/dbmate/db.go
@@ -144,7 +144,7 @@ func (db *DB) wait(drv Driver) error {
 		}
 	}
 
-	// if we find outselves here, we could not connect within the timeout
+	// if we find ourselves here, we could not connect within the timeout
 	fmt.Fprint(db.Log, "\n")
 	return fmt.Errorf("%w: %s", ErrCantConnect, err)
 }


### PR DESCRIPTION
Three small typos:

- README line 168: `charactors` -> `characters`
- README line 289: `deafult port 8123` -> `default port 8123`
- `pkg/dbmate/db.go` line 147 (comment): `outselves` -> `ourselves`