### PR TITLE
Replace broken Homebrew bump action with brew bump-formula-pr

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@0e0efbef56eccc14b456017747da3f9d04133dc6
+        uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0
+        with:
+          core: true
 
       - name: Bump Homebrew formula
         env:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,14 +3,38 @@ name: Post Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to bump (e.g. v2.34.0)"
+        required: true
 
 jobs:
   homebrew:
     name: Bump Homebrew Formula
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v4.1
-        with:
-          formula-name: dbmate
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@0e0efbef56eccc14b456017747da3f9d04133dc6
+
+      - name: Bump Homebrew formula
         env:
-          COMMITTER_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_GIT_NAME: "Dbmate Release Bot"
+          HOMEBREW_GIT_EMAIL: "55776497+dbmate-releasebot@users.noreply.github.com"
+        run: |
+          tag="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          version="${tag#v}"
+          url="https://github.com/amacneil/dbmate/archive/refs/tags/${tag}.tar.gz"
+
+          git config --global user.name "$HOMEBREW_GIT_NAME"
+          git config --global user.email "$HOMEBREW_GIT_EMAIL"
+
+          brew bump-formula-pr dbmate \
+            --url="$url" \
+            --version="$version" \
+            --fork-org=dbmate-releasebot \
+            --no-audit \
+            --no-browse \
+            --message="For additional details see https://github.com/amacneil/dbmate/releases/tag/${tag}"

--- a/pkg/dbmate/version.go
+++ b/pkg/dbmate/version.go
@@ -1,4 +1,4 @@
 package dbmate
 
 // Version of dbmate
-const Version = "2.34.1"
+const Version = "2.34.2"


### PR DESCRIPTION
## Summary

- Replace `mislav/bump-homebrew-formula-action` with Homebrew's own `brew bump-formula-pr` CLI, which correctly follows GitHub's HTTP 303 tarball redirects ([mislav/bump-homebrew-formula-action#340](https://github.com/mislav/bump-homebrew-formula-action/issues/340))
- Use `Homebrew/actions/setup-homebrew` with `core: true` so the `dbmate` formula is available on Linux CI runners
- Add `workflow_dispatch` input to manually retry a Homebrew bump without cutting a new release tag
- Preserve the existing `dbmate-releasebot` fork-and-PR flow via `--fork-org=dbmate-releasebot` and `RELEASE_TOKEN`

## Test plan

- [x] Triggered `workflow_dispatch` on this branch with `tag=v2.34.1` ([run #29102169692](https://github.com/amacneil/dbmate/actions/runs/29102169692)) — no HTTP 303 error; failed as expected because v2.34.1 is already in homebrew-core via BrewTestBot autobump
- [ ] After merge, confirm the next release tag opens a PR to `Homebrew/homebrew-core` from `dbmate-releasebot`


Made with [Cursor](https://cursor.com)