### PR TITLE
fix: remove extra bound argument in BigQuery InsertMigration

### DIFF
--- a/pkg/driver/bigquery/bigquery.go
+++ b/pkg/driver/bigquery/bigquery.go
@@ -318,7 +318,7 @@ func (drv *Driver) InsertMigration(_ dbutil.Transaction, version string) error {
 
 	queryTemplate := `INSERT INTO %s.%s (version) VALUES ('%s');`
 	queryString := fmt.Sprintf(queryTemplate, config.dataSet, drv.migrationsTableName, version)
-	_, err = db.Exec(queryString, version)
+	_, err = db.Exec(queryString)
 	if err != nil {
 		return err
 	}

--- a/pkg/driver/bigquery/bigquery.go
+++ b/pkg/driver/bigquery/bigquery.go
@@ -283,7 +283,7 @@ func (drv *Driver) MigrationsTableExists(db *sql.DB) (bool, error) {
 	return exists, nil
 }
 
-func (drv *Driver) DeleteMigration(util dbutil.Transaction, version string) error {
+func (drv *Driver) DeleteMigration(tx dbutil.Transaction, version string) error {
 	db, err := drv.Open()
 	if err != nil {
 		return err
@@ -295,8 +295,8 @@ func (drv *Driver) DeleteMigration(util dbutil.Transaction, version string) erro
 		return err
 	}
 
-	query := fmt.Sprintf("DELETE FROM %s.%s WHERE version = '%s';", config.dataSet, drv.migrationsTableName, version)
-	_, err = util.Exec(query)
+	query := fmt.Sprintf("DELETE FROM %s.%s WHERE version = ?;", config.dataSet, drv.migrationsTableName)
+	_, err = tx.Exec(query, version)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func (drv *Driver) DeleteMigration(util dbutil.Transaction, version string) erro
 	return nil
 }
 
-func (drv *Driver) InsertMigration(_ dbutil.Transaction, version string) error {
+func (drv *Driver) InsertMigration(tx dbutil.Transaction, version string) error {
 	db, err := drv.Open()
 	if err != nil {
 		return err
@@ -316,9 +316,8 @@ func (drv *Driver) InsertMigration(_ dbutil.Transaction, version string) error {
 		return err
 	}
 
-	queryTemplate := `INSERT INTO %s.%s (version) VALUES ('%s');`
-	queryString := fmt.Sprintf(queryTemplate, config.dataSet, drv.migrationsTableName, version)
-	_, err = db.Exec(queryString)
+	query := fmt.Sprintf("INSERT INTO %s.%s (version) VALUES (?);", config.dataSet, drv.migrationsTableName)
+	_, err = tx.Exec(query, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`InsertMigration` in the BigQuery driver interpolates `version` into the SQL string, then also passes it to `db.Exec` as a bound argument. The query has no placeholders, so the argument has nothing to bind to. Real BigQuery silently ignores it, but newer versions of goccy/bigquery-emulator reject the insert:

```
googleapi: Error 400: failed to exec INSERT INTO ... : sql: expected 0 arguments, got 1
```

This makes `dbmate up` fail against the emulator right after applying the first migration. `DeleteMigration` does the same interpolation without the extra argument, so this looks like a leftover from #523.

Following review, both `InsertMigration` and `DeleteMigration` now bind `version` as a query parameter instead of interpolating it into the SQL, and `InsertMigration` runs on the transaction `Migrate()` passes in (as `DeleteMigration` already did).

Tested the `pkg/driver/bigquery` suite against emulator 0.4.4 (the version pinned in docker-compose.yml, which tolerates the extra arg) and 0.8.1 (which rejects it) - passes on both. CI doesn't catch this today because it pins 0.4.4; happy to bump the image here or in a follow-up if you want the regression covered.
